### PR TITLE
Remove support for bytes

### DIFF
--- a/src/biip/gs1/_application_identifiers.py
+++ b/src/biip/gs1/_application_identifiers.py
@@ -94,7 +94,6 @@ class GS1ApplicationIdentifier:
             Metadata about the extracted AI.
 
         Raises:
-            TypeError: If the input isn't str or bytes.
             ParseError: If the parsing fails.
 
         Example:
@@ -104,15 +103,8 @@ class GS1ApplicationIdentifier:
             Number (GTIN)', data_title='GTIN', fnc1_required=False,
             format='N2+N14')
         """
-        if isinstance(value, str):
-            data = value.encode()
-        elif isinstance(value, bytes):
-            data = value
-        else:
-            raise TypeError(f"Expected str or bytes, got {type(value)}.")
-
         for application_identifier in _GS1_APPLICATION_IDENTIFIERS:
-            if data.startswith(application_identifier.ai.encode()):
+            if value.startswith(application_identifier.ai):
                 return application_identifier
 
         raise ParseError(

--- a/tests/gs1/test_application_identifiers.py
+++ b/tests/gs1/test_application_identifiers.py
@@ -57,13 +57,6 @@ def test_extract_unknown_gs1_ai(unknown_ai: str) -> None:
     )
 
 
-def test_extract_from_invalid_type() -> None:
-    with pytest.raises(TypeError) as exc_info:
-        GS1ApplicationIdentifier.extract(1234)  # type: ignore
-
-    assert str(exc_info.value) == "Expected str or bytes, got <class 'int'>."
-
-
 @pytest.mark.parametrize(
     "value, expected",
     [
@@ -79,7 +72,7 @@ def test_extract_from_invalid_type() -> None:
             ),
         ),
         (
-            b"90SE011\x1d2501611262",
+            "90SE011\x1d2501611262",
             GS1ApplicationIdentifier(
                 ai="90",
                 description="Information mutually agreed between trading partners",


### PR DESCRIPTION
`\x1d` and all characters allowed in GS1 data can equally well be represented as Unicode.