### PR TITLE
Accept multiple separator chars

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,12 @@
 Changes
 =======
 
+v0.5.0 (UNRELEASED)
+===================
+
+- **Breaking change:** Change argument `separator_char` to `separator_chars` in
+  plural, accepting an iterable of multiple characters.
+
 v0.4.0 (2020-08-31)
 ===================
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -457,7 +457,7 @@ as this character cannot legally be a part of the payload in Element Strings.
 If we configure the barcode scanner to use an alternative separator character,
 we also need to tell Biip what character to expect::
 
-    >>> result = biip.parse("0107032069804988100329|15210525", separator_char="|")
+    >>> result = biip.parse("0107032069804988100329|15210525", separator_chars=["|"])
     >>> result.gs1_message.as_hri()
     '(01)07032069804988(10)0329(15)210525'
 

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional, Type, Union
+from typing import Iterable, List, Optional, Type, Union
 
 from biip import ParseError
-from biip.gs1 import DEFAULT_SEPARATOR_CHAR, GS1Message, GS1Symbology
+from biip.gs1 import DEFAULT_SEPARATOR_CHARS, GS1Message, GS1Symbology
 from biip.gtin import Gtin, RcnRegion
 from biip.sscc import Sscc
 from biip.symbology import SymbologyIdentifier
@@ -19,7 +19,7 @@ def parse(
     value: str,
     *,
     rcn_region: Optional[RcnRegion] = None,
-    separator_char: str = DEFAULT_SEPARATOR_CHAR,
+    separator_chars: Iterable[str] = DEFAULT_SEPARATOR_CHARS,
 ) -> ParseResult:
     """Identify data format and parse data.
 
@@ -34,11 +34,11 @@ def parse(
         rcn_region: The geographical region whose rules should be used to
             interpret Restricted Circulation Numbers (RCN).
             Needed to extract e.g. variable weight/price from GTIN.
-        separator_char: Character used in place of the FNC1 symbol.
+        separator_chars: Characters used in place of the FNC1 symbol.
             Defaults to `<GS>` (ASCII value 29).
             If variable-length fields in the middle of the message are
-            not terminated with this character, the parser might greedily
-            consume the rest of the message.
+            not terminated with a separator character, the parser might
+            greedily consume the rest of the message.
 
     Returns:
         A data class depending upon what type of data is parsed.
@@ -89,7 +89,9 @@ def parse(
         if parser == GS1Message:
             try:
                 result.gs1_message = GS1Message.parse(
-                    value, rcn_region=rcn_region, separator_char=separator_char
+                    value,
+                    rcn_region=rcn_region,
+                    separator_chars=separator_chars,
                 )
             except ParseError as exc:
                 result.gs1_message_error = str(exc)

--- a/src/biip/gs1/__init__.py
+++ b/src/biip/gs1/__init__.py
@@ -43,12 +43,14 @@ Example:
 
 from __future__ import annotations
 
+from typing import Tuple
+
 
 #: The default separator character is <GS>, ASCII value 29.
 #:
 #: References:
 #:   GS1 General Specifications, section 7.8.3.
-DEFAULT_SEPARATOR_CHAR = "\x1d"
+DEFAULT_SEPARATOR_CHARS: Tuple[str] = ("\x1d",)
 
 
 from biip.gs1._symbology import GS1Symbology  # noqa

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -342,7 +342,7 @@ def test_parse_strips_symbology_identifier() -> None:
 
 
 def test_parse_with_separator_char() -> None:
-    result = parse("101313|15210526", separator_char="|")
+    result = parse("101313|15210526", separator_chars=["|"])
 
     assert result.gs1_message is not None
     assert result.gs1_message.as_hri() == "(10)1313(15)210526"


### PR DESCRIPTION
This is useful if you have multiple sources of barcode data, some using default `<GS>` separator characters and others needing to use an alternative separator character.