### PR TITLE
Extended UPC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Please open an issue if you have and barcode parsing related needs that are not 
 - SSCC (Serial Shipping Container Code)
   - Validate check digit.
   - Encode for human consumption, with the logical groups separated by whitespace.
+- UPC (Universal Product Code)
+  - Parse 12-digit UPC-A,
+  - Parse 6-digit UPC-E, with implicit number system 0 and no check digit.
+  - Parse 7-digit UPC-E, with explicit number system and no check digit.
+  - Parse 8-digit UPC-E, with explicit number system and a check digit.
+  - Expand UPC-E to UPC-A.
+  - Suppress UPC-A to UPC-E, for the values where it is supported.
 - Symbology Identifers, e.g. `]EO`
   - Recognize all specified Symbology Identifier code characters.
   - Strip Symbology Identifers before parsing the remainder.

--- a/docs/api/upc.rst
+++ b/docs/api/upc.rst
@@ -1,0 +1,6 @@
+========
+biip.upc
+========
+
+.. automodule:: biip.upc
+    :members:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,6 +64,7 @@ Project resources
     api/gtin
     api/sscc
     api/symbology
+    api/upc
 
 
 License

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,4 +1,11 @@
 [darglint]
+ignore =
+    # DAR402: Excess exceptions in Raises section
+    # (we know they are raised from called function)
+    DAR402
+ignore_raise =
+    # Exception is used for cases that are bugs and should never happen.
+    Exception
 strictness = short
 
 [flake8]

--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -34,6 +34,7 @@ Example:
         ...
     biip._exceptions.ParseError: Failed to parse '123':
     - GTIN: Failed to parse '123' as GTIN: Expected 8, 12, 13, or 14 digits, got 3.
+    - UPC: Failed to parse '123' as UPC: Expected 6, 7, 8, or 12 digits, got 3.
     - SSCC: Failed to parse '123' as SSCC: Expected 18 digits, got 3.
     - GS1: Failed to match '123' with GS1 AI (12) pattern '^12(\d{6})$'.
 """

--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -16,18 +16,18 @@ Example:
     pattern_groups=['385074'], gtin=None, sscc=None, date=None, decimal=None,
     money=None)])
     >>> # Value that is only valid as a GS1 Message:
-    >>> result = biip.parse("15210526")
+    >>> result = biip.parse("15210527")
     >>> result.gtin
     None
     >>> result.gtin_error
-    "Invalid GTIN check digit for '15210526': Expected 4, got 6."
+    "Invalid GTIN check digit for '15210527': Expected 4, got 7."
     >>> result.gs1_message
-    GS1Message(value='15210526',
+    GS1Message(value='15210527',
     element_strings=[GS1ElementString(ai=GS1ApplicationIdentifier(ai='15',
     description='Best before date (YYMMDD)', data_title='BEST BEFORE or BEST
-    BY', fnc1_required=False, format='N2+N6'), value='210526',
-    pattern_groups=['210526'], gtin=None, sscc=None, date=datetime.date(2021,
-    5, 26), decimal=None, money=None)])
+    BY', fnc1_required=False, format='N2+N6'), value='210527',
+    pattern_groups=['210527'], gtin=None, sscc=None, date=datetime.date(2021,
+    5, 27), decimal=None, money=None)])
     >>> # Value that cannot be interpreted as any supported format:
     >>> biip.parse("123")
     Traceback (most recent call last):

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -10,7 +10,7 @@ from biip.sscc import Sscc
 from biip.symbology import SymbologyIdentifier
 from biip.upc import Upc
 
-ParserType = Union[Type[GS1Message], Type[Gtin], Type[Sscc]]
+ParserType = Union[Type[GS1Message], Type[Gtin], Type[Sscc], Type[Upc]]
 
 
 def parse(
@@ -65,7 +65,7 @@ def parse(
     if not parsers:
         # If we're not able to select a subset based on Symbology Identifiers,
         # run all parsers in the default order.
-        parsers = [Gtin, Sscc, GS1Message]
+        parsers = [Upc, Gtin, Sscc, GS1Message]
 
     # Run all parsers in order
     for parser in parsers:
@@ -104,6 +104,12 @@ def parse(
                 result.sscc = Sscc.parse(value)
             except ParseError as exc:
                 result.sscc_error = str(exc)
+
+        if parser == Upc:
+            try:
+                result.upc = Upc.parse(value)
+            except ParseError as exc:
+                result.upc_error = str(exc)
 
     if result._has_result():
         return result

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -5,7 +5,7 @@ from typing import Iterable, List, Optional, Type, Union
 
 from biip import ParseError
 from biip.gs1 import DEFAULT_SEPARATOR_CHARS, GS1Message, GS1Symbology
-from biip.gtin import Gtin, RcnRegion
+from biip.gtin import Gtin, GtinFormat, RcnRegion
 from biip.sscc import Sscc
 from biip.symbology import SymbologyIdentifier
 from biip.upc import Upc
@@ -92,6 +92,14 @@ def parse(
                     result.gtin = ai_01.gtin
                     # Clear error from parsing full value as GTIN.
                     result.gtin_error = None
+
+                    # If contained GTIN is a GTIN-12, also parse it as UPC.
+                    if ai_01.gtin and ai_01.gtin.format == GtinFormat.GTIN_12:
+                        try:
+                            result.upc = Upc.parse(ai_01.gtin.as_gtin_12())
+                            result.upc_error = None
+                        except ParseError as exc:
+                            result.upc_error = str(exc)
 
         if parser == Gtin:
             try:

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -8,6 +8,7 @@ from biip.gs1 import DEFAULT_SEPARATOR_CHARS, GS1Message, GS1Symbology
 from biip.gtin import Gtin, RcnRegion
 from biip.sscc import Sscc
 from biip.symbology import SymbologyIdentifier
+from biip.upc import Upc
 
 ParserType = Union[Type[GS1Message], Type[Gtin], Type[Sscc]]
 
@@ -127,6 +128,12 @@ class ParseResult:
     #: The GTIN parse error, if parsing as a GTIN was attempted and failed.
     gtin_error: Optional[str] = None
 
+    #: The extracted UPC, if any.
+    upc: Optional[Upc] = None
+
+    #: The UPC parse error, if parsing as an UPC was attempted and failed.
+    upc_error: Optional[str] = None
+
     #: The extracted SSCC, if any.
     #: Is also set if a GS1 Message containing an SSCC was successfully parsed.
     sscc: Optional[Sscc] = None
@@ -142,13 +149,14 @@ class ParseResult:
     gs1_message_error: Optional[str] = None
 
     def _has_result(self: "ParseResult") -> bool:
-        return any([self.gtin, self.sscc, self.gs1_message])
+        return any([self.gtin, self.upc, self.sscc, self.gs1_message])
 
     def _get_errors_list(self: "ParseResult") -> str:
         return "\n".join(
             f"- {parser_name}: {error}"
             for parser_name, error in [
                 ("GTIN", self.gtin_error),
+                ("UPC", self.upc_error),
                 ("SSCC", self.sscc_error),
                 ("GS1", self.gs1_message_error),
             ]

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -13,8 +13,8 @@ Example:
     >>> from biip.upc import Upc
     >>> upc_a = Upc.parse("042100005264")
     >>> upc_a
-    Upc(value='042100005264', format=UpcFormat.UPC_A, payload='04210000526',
-    number_system_digit=0, check_digit=4)
+    Upc(value='042100005264', format=UpcFormat.UPC_A, number_system_digit=0,
+    payload='04210000526', check_digit=4)
 
 A subset of the UPC-A values can be converted to a shorter UPC-E format by
 suppressing zeros.
@@ -28,8 +28,8 @@ All UPC-E values can be expanded to an UPC-A.
 Example:
     >>> upc_e = Upc.parse("04252614")
     >>> upc_e
-    Upc(value='04252614', format=UpcFormat.UPC_E, payload='0425261',
-    number_system_digit=0, check_digit=4)
+    Upc(value='04252614', format=UpcFormat.UPC_E, number_system_digit=0,
+    payload='0425261', check_digit=4)
     >>> upc_e.as_upc_a()
     '042100005264'
 
@@ -75,12 +75,12 @@ class Upc:
     #: UPC format, either UPC-A or UPC-E.
     format: UpcFormat
 
+    #: Number system digit.
+    number_system_digit: int
+
     #: The actual payload, including number system digit, manufacturer code,
     #: and product code. Excludes the check digit.
     payload: str
-
-    #: Number system digit.
-    number_system_digit: int
 
     #: Check digit used to check if the UPC-A as a whole is valid.
     #:

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -1,4 +1,41 @@
-"""Universal Product Code (UPC)."""
+"""Universal Product Code (UPC).
+
+The :mod:`biip.upc` module contains Biip's support for parsing UPC formats.
+
+UPC is a subset of the later GTIN standard: An UPC-A value is also a valid GTIN-12 value.
+
+This class can interpret the following UPC formats:
+
+- UPC-A, 12 digits.
+- UPC-E, 6 digits, with implicit number system 0 and no check digit.
+- UPC-E, 7 digits, with explicit number system and no check digit.
+- UPC-E, 8 digits, with explicit number system and a check digit.
+
+
+Example:
+    >>> from biip.upc import Upc
+    >>> upc_a = Upc.parse("042100005264")
+    >>> upc_a
+    Upc(value='042100005264', format=UpcFormat.UPC_A, payload='04210000526',
+    number_system_digit=0, check_digit=4)
+
+A subset of the UPC-A values can be converted to a shorter UPC-E format by
+suppressing zeros.
+
+Example:
+    >>> upc_a.as_upc_e()
+    '04252614'
+
+All UPC-E values can be expanded to an UPC-A.
+
+Example:
+    >>> upc_e = Upc.parse("04252614")
+    >>> upc_e
+    Upc(value='04252614', format=UpcFormat.UPC_E, payload='0425261',
+    number_system_digit=0, check_digit=4)
+    >>> upc_e.as_upc_a()
+    '042100005264'
+"""
 
 from dataclasses import dataclass
 from enum import Enum
@@ -13,6 +50,10 @@ class UpcFormat(Enum):
 
     UPC_A = "upc_a"
     UPC_E = "upc_e"
+
+    def __repr__(self: "UpcFormat") -> str:
+        """Canonical string representation of format."""
+        return f"UpcFormat.{self.name}"
 
 
 @dataclass

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -2,15 +2,12 @@
 
 The :mod:`biip.upc` module contains Biip's support for parsing UPC formats.
 
-UPC is a subset of the later GTIN standard: An UPC-A value is also a valid GTIN-12 value.
-
 This class can interpret the following UPC formats:
 
 - UPC-A, 12 digits.
 - UPC-E, 6 digits, with implicit number system 0 and no check digit.
 - UPC-E, 7 digits, with explicit number system and no check digit.
 - UPC-E, 8 digits, with explicit number system and a check digit.
-
 
 Example:
     >>> from biip.upc import Upc
@@ -35,6 +32,18 @@ Example:
     number_system_digit=0, check_digit=4)
     >>> upc_e.as_upc_a()
     '042100005264'
+
+UPC is a subset of the later GTIN standard: An UPC-A value is also a valid GTIN-12 value.
+
+Example:
+    >>> upc_e.as_gtin_12()
+    '042100005264'
+
+The canonical format for persisting UPCs to e.g. a database is GTIN-14.
+
+Example:
+    >>> upc_e.as_gtin_14()
+    '00042100005264'
 """
 
 from dataclasses import dataclass
@@ -220,6 +229,24 @@ class Upc:
         raise Exception(  # pragma: no cover
             "Unhandled case while formatting as UPC-E. This is a bug."
         )
+
+    def as_gtin_12(self: "Upc") -> str:
+        """Format as GTIN-12."""
+        from biip.gtin import Gtin
+
+        return Gtin.parse(self.as_upc_a()).as_gtin_12()
+
+    def as_gtin_13(self: "Upc") -> str:
+        """Format as GTIN-13."""
+        from biip.gtin import Gtin
+
+        return Gtin.parse(self.as_upc_a()).as_gtin_13()
+
+    def as_gtin_14(self: "Upc") -> str:
+        """Format as GTIN-14."""
+        from biip.gtin import Gtin
+
+        return Gtin.parse(self.as_upc_a()).as_gtin_14()
 
 
 def _upc_e_to_upc_a_expansion(value: str) -> str:

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -167,18 +167,25 @@ class Upc:
             number_system_digit = int(value[0])
             payload = value[:-1]
             check_digit = int(value[-1])
-
-            # Control that check digit is correct.
-            upc_a_payload = _upc_e_to_upc_a_expansion(value)[:-1]
-            calculated_check_digit = numeric_check_digit(upc_a_payload)
-            if check_digit != calculated_check_digit:
-                raise ParseError(
-                    f"Invalid UPC-E check digit for {value!r}: "
-                    f"Expected {calculated_check_digit!r}, got {check_digit!r}."
-                )
         else:
             raise Exception(  # pragma: no cover
                 "Unhandled UPC-E length. This is a bug."
+            )
+
+        # Control that the number system digit is correct.
+        if number_system_digit not in (0, 1):
+            raise ParseError(
+                f"Invalid UPC-E number system for {value!r}: "
+                f"Expected 0 or 1, got {number_system_digit!r}."
+            )
+
+        # Control that check digit is correct.
+        upc_a_payload = _upc_e_to_upc_a_expansion(f"{payload}{check_digit}")[:-1]
+        calculated_check_digit = numeric_check_digit(upc_a_payload)
+        if check_digit != calculated_check_digit:
+            raise ParseError(
+                f"Invalid UPC-E check digit for {value!r}: "
+                f"Expected {calculated_check_digit!r}, got {check_digit!r}."
             )
 
         return cls(

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -29,6 +29,9 @@ class Upc:
     #: and product code. Excludes the check digit.
     payload: str
 
+    #: Number system digit.
+    number_system_digit: int
+
     #: Check digit used to check if the UPC-A as a whole is valid.
     #:
     #: Set for UPC-A, but not set for UPC-E.
@@ -50,27 +53,31 @@ class Upc:
         """
         value = value.strip()
 
+        length = len(value)
+        if length not in (6, 7, 8, 12):
+            raise ParseError(
+                f"Failed to parse {value!r} as UPC: "
+                f"Expected 6, 7, 8, or 12 digits, got {length}."
+            )
+
         if not value.isnumeric():
             raise ParseError(
                 f"Failed to parse {value!r} as UPC: Expected a numerical value."
             )
 
-        length = len(value)
         if length == 12:
             return cls._parse_upc_a(value)
-        elif length == 6:
+        elif length in (6, 7, 8):
             return cls._parse_upc_e(value)
-        else:
-            raise ParseError(
-                f"Failed to parse {value!r} as UPC: "
-                f"Expected 6 or 12 digits, got {length}."
-            )
+
+        raise Exception("Unhandled UPC length. This is a bug.")  # pragma: no cover
 
     @classmethod
     def _parse_upc_a(cls: Type["Upc"], value: str) -> "Upc":
         assert len(value) == 12
 
         payload = value[:-1]
+        number_system_digit = int(value[0])
         check_digit = int(value[-1])
 
         calculated_check_digit = numeric_check_digit(payload)
@@ -84,18 +91,47 @@ class Upc:
             value=value,
             format=UpcFormat.UPC_A,
             payload=payload,
+            number_system_digit=number_system_digit,
             check_digit=check_digit,
         )
 
     @classmethod
     def _parse_upc_e(cls: Type["Upc"], value: str) -> "Upc":
-        assert len(value) == 6
+        length = len(value)
+        assert length in (6, 7, 8)
 
-        # TODO: Check UPC-E parity pattern.
+        if length == 6:
+            # Implicit number system 0, no check digit.
+            number_system_digit = 0
+            payload = f"{number_system_digit}{value}"
+            check_digit = numeric_check_digit(payload)
+        elif length == 7:
+            # Explicit number system, no check digit.
+            number_system_digit = int(value[0])
+            payload = value
+            check_digit = numeric_check_digit(payload)
+        elif length == 8:
+            # Explicit number system and check digit.
+            number_system_digit = int(value[0])
+            payload = value[:-1]
+            check_digit = int(value[-1])
+
+            # TODO: Expand UPC-E to UPC-A before calculating check digit
+            # calculated_check_digit = numeric_check_digit(payload)
+            # if check_digit != calculated_check_digit:
+            #     raise ParseError(
+            #         f"Invalid UPC-E check digit for {value!r}: "
+            #         f"Expected {calculated_check_digit!r}, got {check_digit!r}."
+            #     )
+        else:
+            raise Exception(  # pragma: no cover
+                "Unhandled UPC-E length. This is a bug."
+            )
 
         return cls(
             value=value,
             format=UpcFormat.UPC_E,
-            payload=value,
-            check_digit=None,
+            payload=payload,
+            number_system_digit=number_system_digit,
+            check_digit=check_digit,
         )

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -1,0 +1,101 @@
+"""Universal Product Code (UPC)."""
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional, Type
+
+from biip import ParseError
+from biip.gs1.checksums import numeric_check_digit
+
+
+class UpcFormat(Enum):
+    """Enum of UPC formats."""
+
+    UPC_A = "upc_a"
+    UPC_E = "upc_e"
+
+
+@dataclass
+class Upc:
+    """Data class containing an UPC."""
+
+    #: Raw unprocessed value.
+    value: str
+
+    #: UPC format, either UPC-A or UPC-E.
+    format: UpcFormat
+
+    #: The actual payload, including number system digit, manufacturer code,
+    #: and product code. Excludes the check digit.
+    payload: str
+
+    #: Check digit used to check if the UPC-A as a whole is valid.
+    #:
+    #: Set for UPC-A, but not set for UPC-E.
+    check_digit: Optional[int] = None
+
+    @classmethod
+    def parse(cls: Type["Upc"], value: str) -> "Upc":
+        """Parse the given value into a :class:`Upc` object.
+
+        Args:
+            value: The value to parse.
+
+        Returns:
+            UPC data structure with the successfully extracted data.
+            The checksum is guaranteed to be valid if an UPC object is returned.
+
+        Raises:
+            ParseError: If the parsing fails.
+        """
+        value = value.strip()
+
+        if not value.isnumeric():
+            raise ParseError(
+                f"Failed to parse {value!r} as UPC: Expected a numerical value."
+            )
+
+        length = len(value)
+        if length == 12:
+            return cls._parse_upc_a(value)
+        elif length == 6:
+            return cls._parse_upc_e(value)
+        else:
+            raise ParseError(
+                f"Failed to parse {value!r} as UPC: "
+                f"Expected 6 or 12 digits, got {length}."
+            )
+
+    @classmethod
+    def _parse_upc_a(cls: Type["Upc"], value: str) -> "Upc":
+        assert len(value) == 12
+
+        payload = value[:-1]
+        check_digit = int(value[-1])
+
+        calculated_check_digit = numeric_check_digit(payload)
+        if check_digit != calculated_check_digit:
+            raise ParseError(
+                f"Invalid UPC-A check digit for {value!r}: "
+                f"Expected {calculated_check_digit!r}, got {check_digit!r}."
+            )
+
+        return cls(
+            value=value,
+            format=UpcFormat.UPC_A,
+            payload=payload,
+            check_digit=check_digit,
+        )
+
+    @classmethod
+    def _parse_upc_e(cls: Type["Upc"], value: str) -> "Upc":
+        assert len(value) == 6
+
+        # TODO: Check UPC-E parity pattern.
+
+        return cls(
+            value=value,
+            format=UpcFormat.UPC_E,
+            payload=value,
+            check_digit=None,
+        )

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -136,6 +136,25 @@ class Upc:
             check_digit=check_digit,
         )
 
+    def as_upc_a(self: "Upc") -> str:
+        """Format as UPC-A.
+
+        Returns:
+            A string with the UPC encoded as UPC-A.
+
+        References:
+            https://www.barcodefaq.com/barcode-properties/symbologies/upc-e/
+        """
+        if self.format == UpcFormat.UPC_A:
+            return f"{self.payload}{self.check_digit}"
+
+        if self.format == UpcFormat.UPC_E:
+            return self._upc_e_to_upc_a_expansion()
+
+        raise Exception(  # pragma: no cover
+            "Unhandled case while formatting as UPC-E. This is a bug."
+        )
+
     def as_upc_e(self: "Upc") -> str:
         """Format as UPC-E.
 
@@ -156,6 +175,30 @@ class Upc:
 
         raise Exception(  # pragma: no cover
             "Unhandled case while formatting as UPC-E. This is a bug."
+        )
+
+    def _upc_e_to_upc_a_expansion(self: "Upc") -> str:
+        assert self.format == UpcFormat.UPC_E
+
+        last_digit = int(self.payload[6])
+
+        if last_digit in (0, 1, 2):
+            return (
+                f"{self.payload[:3]}{last_digit}0000"
+                f"{self.payload[3:6]}{self.check_digit}"
+            )
+
+        if last_digit == 3:
+            return f"{self.payload[:4]}00000{self.payload[4:6]}{self.check_digit}"
+
+        if last_digit == 4:
+            return f"{self.payload[:5]}00000{self.payload[5]}{self.check_digit}"
+
+        if last_digit in (5, 6, 7, 8, 9):
+            return f"{self.payload[:6]}0000{last_digit}{self.check_digit}"
+
+        raise Exception(  # pragma: no cover
+            "Unhandled case while expanding UPC-E to UPC-A. This is a bug."
         )
 
     def _upc_a_to_upc_e_suppression(self: "Upc") -> str:

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Optional, Type
 
-from biip import ParseError
+from biip import EncodeError, ParseError
 from biip.gs1.checksums import numeric_check_digit
 
 
@@ -135,3 +135,17 @@ class Upc:
             number_system_digit=number_system_digit,
             check_digit=check_digit,
         )
+
+    def as_upc_e(self: "Upc") -> str:
+        """Format as UPC-E.
+
+        Returns:
+            A string with the UPC encoded as UPC-E, if possible.
+
+        Raises:
+            EncodeError: If encoding as UPC-E fails.
+        """
+        if self.format == UpcFormat.UPC_E:
+            return f"{self.payload}{self.check_digit}"
+
+        raise EncodeError(f"Failed encoding UPC format {self.format!r} as UPC-E.")

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -104,25 +104,28 @@ class Upc:
             # Implicit number system 0, no check digit.
             number_system_digit = 0
             payload = f"{number_system_digit}{value}"
-            check_digit = numeric_check_digit(payload)
+            upc_a_payload = _upc_e_to_upc_a_expansion(f"{payload}0")[:-1]
+            check_digit = numeric_check_digit(upc_a_payload)
         elif length == 7:
             # Explicit number system, no check digit.
             number_system_digit = int(value[0])
             payload = value
-            check_digit = numeric_check_digit(payload)
+            upc_a_payload = _upc_e_to_upc_a_expansion(f"{payload}0")[:-1]
+            check_digit = numeric_check_digit(upc_a_payload)
         elif length == 8:
             # Explicit number system and check digit.
             number_system_digit = int(value[0])
             payload = value[:-1]
             check_digit = int(value[-1])
 
-            # TODO: Expand UPC-E to UPC-A before calculating check digit
-            # calculated_check_digit = numeric_check_digit(payload)
-            # if check_digit != calculated_check_digit:
-            #     raise ParseError(
-            #         f"Invalid UPC-E check digit for {value!r}: "
-            #         f"Expected {calculated_check_digit!r}, got {check_digit!r}."
-            #     )
+            # Control that check digit is correct.
+            upc_a_payload = _upc_e_to_upc_a_expansion(value)[:-1]
+            calculated_check_digit = numeric_check_digit(upc_a_payload)
+            if check_digit != calculated_check_digit:
+                raise ParseError(
+                    f"Invalid UPC-E check digit for {value!r}: "
+                    f"Expected {calculated_check_digit!r}, got {check_digit!r}."
+                )
         else:
             raise Exception(  # pragma: no cover
                 "Unhandled UPC-E length. This is a bug."

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -13,6 +13,7 @@ from biip.gs1 import (
 from biip.gtin import Gtin, GtinFormat
 from biip.sscc import Sscc
 from biip.symbology import Symbology, SymbologyIdentifier
+from biip.upc import Upc, UpcFormat
 
 
 @pytest.mark.parametrize(
@@ -30,6 +31,10 @@ from biip.symbology import Symbology, SymbologyIdentifier
                     payload="9638507",
                     check_digit=4,
                 ),
+                upc_error=(
+                    "Invalid UPC-E number system for '96385074': "
+                    "Expected 0 or 1, got 9."
+                ),
                 sscc_error=(
                     "Failed to parse '96385074' as SSCC: Expected 18 digits, got 8."
                 ),
@@ -46,7 +51,7 @@ from biip.symbology import Symbology, SymbologyIdentifier
             ),
         ),
         (
-            # GTIN-12
+            # GTIN-12. GTIN-12 is also valid as UPC-A.
             "123601057072",
             ParseResult(
                 value="123601057072",
@@ -54,6 +59,13 @@ from biip.symbology import Symbology, SymbologyIdentifier
                     value="123601057072",
                     format=GtinFormat.GTIN_12,
                     prefix=GS1Prefix(value="012", usage="GS1 US"),
+                    payload="12360105707",
+                    check_digit=2,
+                ),
+                upc=Upc(
+                    value="123601057072",
+                    format=UpcFormat.UPC_A,
+                    number_system_digit=1,
                     payload="12360105707",
                     check_digit=2,
                 ),
@@ -77,6 +89,10 @@ from biip.symbology import Symbology, SymbologyIdentifier
                     prefix=GS1Prefix(value="590", usage="GS1 Poland"),
                     payload="590123412345",
                     check_digit=7,
+                ),
+                upc_error=(
+                    "Failed to parse '5901234123457' as UPC: "
+                    "Expected 6, 7, 8, or 12 digits, got 13."
                 ),
                 sscc_error=(
                     "Failed to parse '5901234123457' as SSCC: "
@@ -119,6 +135,10 @@ from biip.symbology import Symbology, SymbologyIdentifier
                     payload="590123412345",
                     check_digit=7,
                 ),
+                upc_error=(
+                    "Failed to parse '05901234123457' as UPC: "
+                    "Expected 6, 7, 8, or 12 digits, got 14."
+                ),
                 sscc_error=(
                     "Failed to parse '05901234123457' as SSCC: "
                     "Expected 18 digits, got 14."
@@ -157,6 +177,10 @@ from biip.symbology import Symbology, SymbologyIdentifier
                     "Failed to parse '376130321109103420' as GTIN: "
                     "Expected 8, 12, 13, or 14 digits, got 18."
                 ),
+                upc_error=(
+                    "Failed to parse '376130321109103420' as UPC: "
+                    "Expected 6, 7, 8, or 12 digits, got 18."
+                ),
                 sscc=Sscc(
                     value="376130321109103420",
                     prefix=GS1Prefix(
@@ -179,6 +203,10 @@ from biip.symbology import Symbology, SymbologyIdentifier
                 gtin_error=(
                     "Failed to parse '00376130321109103420' as GTIN: "
                     "Expected 8, 12, 13, or 14 digits, got 20."
+                ),
+                upc_error=(
+                    "Failed to parse '00376130321109103420' as UPC: "
+                    "Expected 6, 7, 8, or 12 digits, got 20."
                 ),
                 sscc=Sscc(
                     value="376130321109103420",
@@ -212,7 +240,7 @@ from biip.symbology import Symbology, SymbologyIdentifier
             ),
         ),
         (
-            # GS1 AI: GTIN
+            # GS1 AI: GTIN-13
             "0105901234123457",
             ParseResult(
                 value="0105901234123457",
@@ -222,6 +250,10 @@ from biip.symbology import Symbology, SymbologyIdentifier
                     prefix=GS1Prefix(value="590", usage="GS1 Poland"),
                     payload="590123412345",
                     check_digit=7,
+                ),
+                upc_error=(
+                    "Failed to parse '0105901234123457' as UPC: "
+                    "Expected 6, 7, 8, or 12 digits, got 16."
                 ),
                 sscc_error=(
                     "Failed to parse '0105901234123457' as SSCC: "
@@ -247,12 +279,19 @@ from biip.symbology import Symbology, SymbologyIdentifier
             ),
         ),
         (
-            # GS1 AI: best before date
+            # GS1 AI: best before date. Coincidentally also a valid UPC-E.
             "15210526",
             ParseResult(
                 value="15210526",
                 gtin_error=(
                     "Invalid GTIN check digit for '15210526': Expected 4, got 6."
+                ),
+                upc=Upc(
+                    value="15210526",
+                    format=UpcFormat.UPC_E,
+                    number_system_digit=1,
+                    payload="1521052",
+                    check_digit=6,
                 ),
                 sscc_error=(
                     "Failed to parse '15210526' as SSCC: Expected 18 digits, got 8."
@@ -352,6 +391,8 @@ def test_parse_invalid_data() -> None:
         "Failed to parse 'abc':\n"
         "- GTIN: Failed to parse 'abc' as GTIN: "
         "Expected 8, 12, 13, or 14 digits, got 3.\n"
+        "- UPC: Failed to parse 'abc' as UPC: "
+        "Expected 6, 7, 8, or 12 digits, got 3.\n"
         "- SSCC: Failed to parse 'abc' as SSCC: Expected 18 digits, got 3.\n"
         "- GS1: Failed to get GS1 Application Identifier from 'abc'."
     )

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -71,6 +71,30 @@ from biip.upc import Upc, UpcFormat
             ),
         ),
         (
+            # Both a valid GTIN-8 and a valid UPC-E. GTIN result should be the
+            # GTIN-8, not the UPC-E expanded to UPC-A/GTIN-12.
+            "12345670",
+            ParseResult(
+                value="12345670",
+                gtin=Gtin(
+                    value="12345670",
+                    format=GtinFormat.GTIN_8,
+                    prefix=GS1Prefix(value="00001", usage="GS1 US"),
+                    payload="1234567",
+                    check_digit=0,
+                ),
+                upc=Upc(
+                    value="12345670",
+                    format=UpcFormat.UPC_E,
+                    number_system_digit=1,
+                    payload="1234567",
+                    check_digit=0,
+                ),
+                sscc_error="Failed to parse '12345670' as SSCC: Expected 18 digits, got 8.",
+                gs1_message_error="Failed to parse GS1 AI (12) date from '345670'.",
+            ),
+        ),
+        (
             # GTIN-12. GTIN-12 is also valid as UPC-A.
             "123601057072",
             ParseResult(

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -79,6 +79,33 @@ from biip.upc import Upc, UpcFormat
             ),
         ),
         (
+            # GTIN-12 with Symbology Identifier. GTIN-12 is also valid as UPC-A.
+            "]E00123601057072",
+            ParseResult(
+                value="]E00123601057072",
+                symbology_identifier=SymbologyIdentifier(
+                    value="]E0",
+                    symbology=Symbology.EAN_UPC,
+                    modifiers="0",
+                    gs1_symbology=GS1Symbology.EAN_13,
+                ),
+                gtin=Gtin(
+                    value="0123601057072",
+                    format=GtinFormat.GTIN_12,
+                    prefix=GS1Prefix(value="012", usage="GS1 US"),
+                    payload="12360105707",
+                    check_digit=2,
+                ),
+                upc=Upc(
+                    value="123601057072",
+                    format=UpcFormat.UPC_A,
+                    number_system_digit=1,
+                    payload="12360105707",
+                    check_digit=2,
+                ),
+            ),
+        ),
+        (
             # GTIN-13
             "5901234123457",
             ParseResult(

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -169,6 +169,45 @@ from biip.upc import Upc, UpcFormat
             ),
         ),
         (
+            # UPC-E. UPC-E is expanded to UPC-A and exposed as GTIN too.
+            # Coincidentally it is also a valid GS1 Message.
+            "425261",
+            ParseResult(
+                value="425261",
+                gtin=Gtin(
+                    value="042100005264",
+                    format=GtinFormat.GTIN_12,
+                    prefix=GS1Prefix(value="004", usage="GS1 US"),
+                    payload="04210000526",
+                    check_digit=4,
+                    packaging_level=None,
+                ),
+                upc=Upc(
+                    value="425261",
+                    format=UpcFormat.UPC_E,
+                    number_system_digit=0,
+                    payload="0425261",
+                    check_digit=4,
+                ),
+                sscc_error="Failed to parse '425261' as SSCC: Expected 18 digits, got 6.",
+                gs1_message=GS1Message(
+                    value="425261",
+                    element_strings=[
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("425"),
+                            value="261",
+                            pattern_groups=["261", ""],
+                            gtin=None,
+                            sscc=None,
+                            date=None,
+                            decimal=None,
+                            money=None,
+                        )
+                    ],
+                ),
+            ),
+        ),
+        (
             # SSCC
             "376130321109103420",
             ParseResult(
@@ -323,31 +362,23 @@ from biip.upc import Upc, UpcFormat
             ),
         ),
         (
-            # GS1 AI: best before date. Coincidentally also a valid UPC-E.
-            "15210526",
+            # GS1 AI: best before date
+            "15210527",
             ParseResult(
-                value="15210526",
-                gtin_error=(
-                    "Invalid GTIN check digit for '15210526': Expected 4, got 6."
-                ),
-                upc=Upc(
-                    value="15210526",
-                    format=UpcFormat.UPC_E,
-                    number_system_digit=1,
-                    payload="1521052",
-                    check_digit=6,
-                ),
+                value="15210527",
+                gtin_error="Invalid GTIN check digit for '15210527': Expected 4, got 7.",
+                upc_error="Invalid UPC-E check digit for '15210527': Expected 6, got 7.",
                 sscc_error=(
-                    "Failed to parse '15210526' as SSCC: Expected 18 digits, got 8."
+                    "Failed to parse '15210527' as SSCC: Expected 18 digits, got 8."
                 ),
                 gs1_message=GS1Message(
-                    value="15210526",
+                    value="15210527",
                     element_strings=[
                         GS1ElementString(
                             ai=GS1ApplicationIdentifier.extract("15"),
-                            value="210526",
-                            pattern_groups=["210526"],
-                            date=date(2021, 5, 26),
+                            value="210527",
+                            pattern_groups=["210527"],
+                            date=date(2021, 5, 27),
                         )
                     ],
                 ),

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -51,6 +51,26 @@ from biip.upc import Upc, UpcFormat
             ),
         ),
         (
+            # GTIN-8 with Symbology Identifier
+            "]E496385074",
+            ParseResult(
+                value="]E496385074",
+                symbology_identifier=SymbologyIdentifier(
+                    value="]E4",
+                    symbology=Symbology.EAN_UPC,
+                    modifiers="4",
+                    gs1_symbology=GS1Symbology.EAN_8,
+                ),
+                gtin=Gtin(
+                    value="96385074",
+                    format=GtinFormat.GTIN_8,
+                    prefix=GS1Prefix(value="00009", usage="GS1 US"),
+                    payload="9638507",
+                    check_digit=4,
+                ),
+            ),
+        ),
+        (
             # GTIN-12. GTIN-12 is also valid as UPC-A.
             "123601057072",
             ParseResult(

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -432,7 +432,7 @@ from biip.upc import Upc, UpcFormat
             ),
         ),
         (
-            # GS1 AI with Symbology Identifier
+            # GS1 AI with GS1-128 Symbology Identifier
             "]C1010590123412345715210526",
             ParseResult(
                 value="]C1010590123412345715210526",
@@ -470,6 +470,50 @@ from biip.upc import Upc, UpcFormat
                             pattern_groups=["210526"],
                             date=date(2021, 5, 26),
                         ),
+                    ],
+                ),
+            ),
+        ),
+        (
+            # GS1 AI with GS1 DataBar Symbology Identifier
+            "]e00100123456789012",
+            ParseResult(
+                value="]e00100123456789012",
+                symbology_identifier=SymbologyIdentifier(
+                    value="]e0",
+                    symbology=Symbology.RSS_EAN_UCC_COMPOSITE,
+                    modifiers="0",
+                    gs1_symbology=GS1Symbology.GS1_DATABAR,
+                ),
+                gtin=Gtin(
+                    value="00123456789012",
+                    format=GtinFormat.GTIN_12,
+                    prefix=GS1Prefix(value="012", usage="GS1 US"),
+                    payload="12345678901",
+                    check_digit=2,
+                ),
+                upc=Upc(
+                    value="123456789012",
+                    format=UpcFormat.UPC_A,
+                    number_system_digit=1,
+                    payload="12345678901",
+                    check_digit=2,
+                ),
+                gs1_message=GS1Message(
+                    value="0100123456789012",
+                    element_strings=[
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("01"),
+                            value="00123456789012",
+                            pattern_groups=["00123456789012"],
+                            gtin=Gtin(
+                                value="00123456789012",
+                                format=GtinFormat.GTIN_12,
+                                prefix=GS1Prefix(value="012", usage="GS1 US"),
+                                payload="12345678901",
+                                check_digit=2,
+                            ),
+                        )
                     ],
                 ),
             ),

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -240,6 +240,50 @@ from biip.upc import Upc, UpcFormat
             ),
         ),
         (
+            # GS1 AI: GTIN-12. GTIN-12 is also valid as UPC-A.
+            "0100123601057072",
+            ParseResult(
+                value="0100123601057072",
+                gtin=Gtin(
+                    value="00123601057072",
+                    format=GtinFormat.GTIN_12,
+                    prefix=GS1Prefix(value="012", usage="GS1 US"),
+                    payload="12360105707",
+                    check_digit=2,
+                    packaging_level=None,
+                ),
+                upc=Upc(
+                    value="123601057072",
+                    format=UpcFormat.UPC_A,
+                    number_system_digit=1,
+                    payload="12360105707",
+                    check_digit=2,
+                ),
+                sscc_error=(
+                    "Failed to parse '0100123601057072' as SSCC: "
+                    "Expected 18 digits, got 16."
+                ),
+                gs1_message=GS1Message(
+                    value="0100123601057072",
+                    element_strings=[
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("01"),
+                            value="00123601057072",
+                            pattern_groups=["00123601057072"],
+                            gtin=Gtin(
+                                value="00123601057072",
+                                format=GtinFormat.GTIN_12,
+                                prefix=GS1Prefix(value="012", usage="GS1 US"),
+                                payload="12360105707",
+                                check_digit=2,
+                                packaging_level=None,
+                            ),
+                        )
+                    ],
+                ),
+            ),
+        ),
+        (
             # GS1 AI: GTIN-13
             "0105901234123457",
             ParseResult(

--- a/tests/test_upc.py
+++ b/tests/test_upc.py
@@ -28,7 +28,7 @@ def test_parse_upc_a() -> None:
                 format=UpcFormat.UPC_E,
                 payload="0425261",
                 number_system_digit=0,
-                check_digit=0,
+                check_digit=4,
             ),
         ),
         (
@@ -38,17 +38,17 @@ def test_parse_upc_a() -> None:
                 format=UpcFormat.UPC_E,
                 payload="1425261",
                 number_system_digit=1,
-                check_digit=7,
+                check_digit=1,
             ),
         ),
         (
-            "14252617",  # Length is 8: Explicit number system 1 and check digit.
+            "14252611",  # Length is 8: Explicit number system 1 and check digit.
             Upc(
-                value="14252617",
+                value="14252611",
                 format=UpcFormat.UPC_E,
                 payload="1425261",
                 number_system_digit=1,
-                check_digit=7,
+                check_digit=1,
             ),
         ),
     ],
@@ -84,6 +84,16 @@ def test_parse_upc_a_with_invalid_check_digit() -> None:
     assert (
         str(exc_info.value)
         == "Invalid UPC-A check digit for '042100005263': Expected 4, got 3."
+    )
+
+
+def test_parse_upc_e_with_invalid_check_digit() -> None:
+    with pytest.raises(ParseError) as exc_info:
+        Upc.parse("04252613")
+
+    assert (
+        str(exc_info.value)
+        == "Invalid UPC-E check digit for '04252613': Expected 4, got 3."
     )
 
 
@@ -127,15 +137,15 @@ def test_as_upc_a(value: str, expected: str) -> None:
     [
         (  # 6-digit UPC-E, implicit number system 0, no check digit.
             "425261",
-            "04252610",
+            "04252614",
         ),
         (  # 7-digit UPC-E, explicit number system 1, no check digit.
             "1425261",
-            "14252617",
+            "14252611",
         ),
         (  # 8-digit UPC-E, explicit number system 1, with check digit.
-            "14252617",
-            "14252617",
+            "14252611",
+            "14252611",
         ),
         (  # UPC-A suppression, condition A
             "023456000073",

--- a/tests/test_upc.py
+++ b/tests/test_upc.py
@@ -91,3 +91,24 @@ def test_parse_strips_surrounding_whitespace() -> None:
     upc = Upc.parse("  \t 042100005264 \n  ")
 
     assert upc.value == "042100005264"
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (  # 6-digit UPC-E, implicit number system 0, no check digit.
+            "425261",
+            "04252610",
+        ),
+        (  # 7-digit UPC-E, explicit number system 1, no check digit.
+            "1425261",
+            "14252617",
+        ),
+        (  # 8-digit UPC-E, explicit number system 1, with check digit.
+            "14252617",
+            "14252617",
+        ),
+    ],
+)
+def test_as_upc_e(value: str, expected: str) -> None:
+    assert Upc.parse(value).as_upc_e() == expected

--- a/tests/test_upc.py
+++ b/tests/test_upc.py
@@ -13,19 +13,48 @@ def test_parse_upc_a() -> None:
         value="042100005264",
         format=UpcFormat.UPC_A,
         payload="04210000526",
+        number_system_digit=0,
         check_digit=4,
     )
 
 
-def test_parse_upc_e() -> None:
-    upc = Upc.parse("425261")
-
-    assert upc == Upc(
-        value="425261",
-        format=UpcFormat.UPC_E,
-        payload="425261",
-        check_digit=None,
-    )
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (
+            "425261",  # Length is 6: Implicit number system 0, no check digit.
+            Upc(
+                value="425261",
+                format=UpcFormat.UPC_E,
+                payload="0425261",
+                number_system_digit=0,
+                check_digit=0,
+            ),
+        ),
+        (
+            "1425261",  # Length is 7: Explicit number system 1, no check digit.
+            Upc(
+                value="1425261",
+                format=UpcFormat.UPC_E,
+                payload="1425261",
+                number_system_digit=1,
+                check_digit=7,
+            ),
+        ),
+        (
+            "14252617",  # Length is 8: Explicit number system 1 and check digit.
+            Upc(
+                value="14252617",
+                format=UpcFormat.UPC_E,
+                payload="1425261",
+                number_system_digit=1,
+                check_digit=7,
+            ),
+        ),
+    ],
+)
+def test_parse_upc_e(value: str, expected: Upc) -> None:
+    assert Upc.parse(value) == expected
 
 
 def test_parse_value_with_invalid_length() -> None:
@@ -34,7 +63,7 @@ def test_parse_value_with_invalid_length() -> None:
 
     assert (
         str(exc_info.value)
-        == "Failed to parse '123' as UPC: Expected 6 or 12 digits, got 3."
+        == "Failed to parse '123' as UPC: Expected 6, 7, 8, or 12 digits, got 3."
     )
 
 

--- a/tests/test_upc.py
+++ b/tests/test_upc.py
@@ -96,6 +96,35 @@ def test_parse_strips_surrounding_whitespace() -> None:
 @pytest.mark.parametrize(
     "value, expected",
     [
+        (  # UPC-A to UPC-A
+            "123456789012",
+            "123456789012",
+        ),
+        (  # Reverse of UPC-A suppression, condition A
+            "02345673",
+            "023456000073",
+        ),
+        (  # Reverse of UPC-A suppression, condition B
+            "02345147",
+            "023450000017",
+        ),
+        (  # Reverse of UPC-A suppression, condition C
+            "06397126",
+            "063200009716",
+        ),
+        (  # Reverse of UPC-A suppression, condition D
+            "08679339",
+            "086700000939",
+        ),
+    ],
+)
+def test_as_upc_a(value: str, expected: str) -> None:
+    assert Upc.parse(value).as_upc_a() == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
         (  # 6-digit UPC-E, implicit number system 0, no check digit.
             "425261",
             "04252610",

--- a/tests/test_upc.py
+++ b/tests/test_upc.py
@@ -1,0 +1,64 @@
+"""Tests of parsing UPC."""
+
+import pytest
+
+from biip import ParseError
+from biip.upc import Upc, UpcFormat
+
+
+def test_parse_upc_a() -> None:
+    upc = Upc.parse("042100005264")
+
+    assert upc == Upc(
+        value="042100005264",
+        format=UpcFormat.UPC_A,
+        payload="04210000526",
+        check_digit=4,
+    )
+
+
+def test_parse_upc_e() -> None:
+    upc = Upc.parse("425261")
+
+    assert upc == Upc(
+        value="425261",
+        format=UpcFormat.UPC_E,
+        payload="425261",
+        check_digit=None,
+    )
+
+
+def test_parse_value_with_invalid_length() -> None:
+    with pytest.raises(ParseError) as exc_info:
+        Upc.parse("123")
+
+    assert (
+        str(exc_info.value)
+        == "Failed to parse '123' as UPC: Expected 6 or 12 digits, got 3."
+    )
+
+
+def test_parse_nonnumeric_value() -> None:
+    with pytest.raises(ParseError) as exc_info:
+        Upc.parse("012345678abc")
+
+    assert (
+        str(exc_info.value)
+        == "Failed to parse '012345678abc' as UPC: Expected a numerical value."
+    )
+
+
+def test_parse_upc_a_with_invalid_check_digit() -> None:
+    with pytest.raises(ParseError) as exc_info:
+        Upc.parse("042100005263")
+
+    assert (
+        str(exc_info.value)
+        == "Invalid UPC-A check digit for '042100005263': Expected 4, got 3."
+    )
+
+
+def test_parse_strips_surrounding_whitespace() -> None:
+    upc = Upc.parse("  \t 042100005264 \n  ")
+
+    assert upc.value == "042100005264"

--- a/tests/test_upc.py
+++ b/tests/test_upc.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from biip import ParseError
+from biip import EncodeError, ParseError
 from biip.upc import Upc, UpcFormat
 
 
@@ -108,7 +108,30 @@ def test_parse_strips_surrounding_whitespace() -> None:
             "14252617",
             "14252617",
         ),
+        (  # UPC-A suppression, condition A
+            "023456000073",
+            "02345673",
+        ),
+        (  # UPC-A suppression, condition B
+            "023450000017",
+            "02345147",
+        ),
+        (  # UPC-A suppression, condition C
+            "063200009716",
+            "06397126",
+        ),
+        (  # UPC-A suppression, condition D
+            "086700000939",
+            "08679339",
+        ),
     ],
 )
 def test_as_upc_e(value: str, expected: str) -> None:
     assert Upc.parse(value).as_upc_e() == expected
+
+
+def test_as_upc_e_when_suppression_is_not_possible() -> None:
+    with pytest.raises(EncodeError) as exc_info:
+        Upc.parse("123456789012").as_upc_e()
+
+    assert str(exc_info.value) == "UPC-A '123456789012' cannot be represented as UPC-E."

--- a/tests/upc/test_encode.py
+++ b/tests/upc/test_encode.py
@@ -1,0 +1,79 @@
+"""Tests of encoding UPCs."""
+
+import pytest
+
+from biip import EncodeError
+from biip.upc import Upc
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (  # UPC-A to UPC-A
+            "123456789012",
+            "123456789012",
+        ),
+        (  # Reverse of UPC-A suppression, condition A
+            "02345673",
+            "023456000073",
+        ),
+        (  # Reverse of UPC-A suppression, condition B
+            "02345147",
+            "023450000017",
+        ),
+        (  # Reverse of UPC-A suppression, condition C
+            "06397126",
+            "063200009716",
+        ),
+        (  # Reverse of UPC-A suppression, condition D
+            "08679339",
+            "086700000939",
+        ),
+    ],
+)
+def test_as_upc_a(value: str, expected: str) -> None:
+    assert Upc.parse(value).as_upc_a() == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (  # 6-digit UPC-E, implicit number system 0, no check digit.
+            "425261",
+            "04252614",
+        ),
+        (  # 7-digit UPC-E, explicit number system 1, no check digit.
+            "1425261",
+            "14252611",
+        ),
+        (  # 8-digit UPC-E, explicit number system 1, with check digit.
+            "14252611",
+            "14252611",
+        ),
+        (  # UPC-A suppression, condition A
+            "023456000073",
+            "02345673",
+        ),
+        (  # UPC-A suppression, condition B
+            "023450000017",
+            "02345147",
+        ),
+        (  # UPC-A suppression, condition C
+            "063200009716",
+            "06397126",
+        ),
+        (  # UPC-A suppression, condition D
+            "086700000939",
+            "08679339",
+        ),
+    ],
+)
+def test_as_upc_e(value: str, expected: str) -> None:
+    assert Upc.parse(value).as_upc_e() == expected
+
+
+def test_as_upc_e_when_suppression_is_not_possible() -> None:
+    with pytest.raises(EncodeError) as exc_info:
+        Upc.parse("123456789012").as_upc_e()
+
+    assert str(exc_info.value) == "UPC-A '123456789012' cannot be represented as UPC-E."

--- a/tests/upc/test_encode.py
+++ b/tests/upc/test_encode.py
@@ -77,3 +77,42 @@ def test_as_upc_e_when_suppression_is_not_possible() -> None:
         Upc.parse("123456789012").as_upc_e()
 
     assert str(exc_info.value) == "UPC-A '123456789012' cannot be represented as UPC-E."
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("425261", "042100005264"),  # UPC-E, 6 digit
+        ("0425261", "042100005264"),  # UPC-E, 7 digit
+        ("04252614", "042100005264"),  # UPC-E, 8 digit
+        ("042100005264", "042100005264"),  # UPC-A
+    ],
+)
+def test_as_gtin_12(value: str, expected: str) -> None:
+    assert Upc.parse(value).as_gtin_12() == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("425261", "0042100005264"),  # UPC-E, 6 digit
+        ("0425261", "0042100005264"),  # UPC-E, 7 digit
+        ("04252614", "0042100005264"),  # UPC-E, 8 digit
+        ("042100005264", "0042100005264"),  # UPC-A
+    ],
+)
+def test_as_gtin_13(value: str, expected: str) -> None:
+    assert Upc.parse(value).as_gtin_13() == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("425261", "00042100005264"),  # UPC-E, 6 digit
+        ("0425261", "00042100005264"),  # UPC-E, 7 digit
+        ("04252614", "00042100005264"),  # UPC-E, 8 digit
+        ("042100005264", "00042100005264"),  # UPC-A
+    ],
+)
+def test_as_gtin_14(value: str, expected: str) -> None:
+    assert Upc.parse(value).as_gtin_14() == expected

--- a/tests/upc/test_parse.py
+++ b/tests/upc/test_parse.py
@@ -1,8 +1,8 @@
-"""Tests of parsing UPC."""
+"""Tests of parsing UPCs."""
 
 import pytest
 
-from biip import EncodeError, ParseError
+from biip import ParseError
 from biip.upc import Upc, UpcFormat
 
 
@@ -101,76 +101,3 @@ def test_parse_strips_surrounding_whitespace() -> None:
     upc = Upc.parse("  \t 042100005264 \n  ")
 
     assert upc.value == "042100005264"
-
-
-@pytest.mark.parametrize(
-    "value, expected",
-    [
-        (  # UPC-A to UPC-A
-            "123456789012",
-            "123456789012",
-        ),
-        (  # Reverse of UPC-A suppression, condition A
-            "02345673",
-            "023456000073",
-        ),
-        (  # Reverse of UPC-A suppression, condition B
-            "02345147",
-            "023450000017",
-        ),
-        (  # Reverse of UPC-A suppression, condition C
-            "06397126",
-            "063200009716",
-        ),
-        (  # Reverse of UPC-A suppression, condition D
-            "08679339",
-            "086700000939",
-        ),
-    ],
-)
-def test_as_upc_a(value: str, expected: str) -> None:
-    assert Upc.parse(value).as_upc_a() == expected
-
-
-@pytest.mark.parametrize(
-    "value, expected",
-    [
-        (  # 6-digit UPC-E, implicit number system 0, no check digit.
-            "425261",
-            "04252614",
-        ),
-        (  # 7-digit UPC-E, explicit number system 1, no check digit.
-            "1425261",
-            "14252611",
-        ),
-        (  # 8-digit UPC-E, explicit number system 1, with check digit.
-            "14252611",
-            "14252611",
-        ),
-        (  # UPC-A suppression, condition A
-            "023456000073",
-            "02345673",
-        ),
-        (  # UPC-A suppression, condition B
-            "023450000017",
-            "02345147",
-        ),
-        (  # UPC-A suppression, condition C
-            "063200009716",
-            "06397126",
-        ),
-        (  # UPC-A suppression, condition D
-            "086700000939",
-            "08679339",
-        ),
-    ],
-)
-def test_as_upc_e(value: str, expected: str) -> None:
-    assert Upc.parse(value).as_upc_e() == expected
-
-
-def test_as_upc_e_when_suppression_is_not_possible() -> None:
-    with pytest.raises(EncodeError) as exc_info:
-        Upc.parse("123456789012").as_upc_e()
-
-    assert str(exc_info.value) == "UPC-A '123456789012' cannot be represented as UPC-E."

--- a/tests/upc/test_parse.py
+++ b/tests/upc/test_parse.py
@@ -97,6 +97,17 @@ def test_parse_upc_e_with_invalid_check_digit() -> None:
     )
 
 
+@pytest.mark.parametrize("number_system", range(2, 10))
+def test_parse_upc_e_with_invalid_number_system(number_system: int) -> None:
+    with pytest.raises(ParseError) as exc_info:
+        Upc.parse(f"{number_system}425261")
+
+    assert str(exc_info.value) == (
+        f"Invalid UPC-E number system for '{number_system}425261': "
+        f"Expected 0 or 1, got {number_system}."
+    )
+
+
 def test_parse_strips_surrounding_whitespace() -> None:
     upc = Upc.parse("  \t 042100005264 \n  ")
 

--- a/tests/upc/test_parse.py
+++ b/tests/upc/test_parse.py
@@ -12,8 +12,8 @@ def test_parse_upc_a() -> None:
     assert upc == Upc(
         value="042100005264",
         format=UpcFormat.UPC_A,
-        payload="04210000526",
         number_system_digit=0,
+        payload="04210000526",
         check_digit=4,
     )
 
@@ -26,8 +26,8 @@ def test_parse_upc_a() -> None:
             Upc(
                 value="425261",
                 format=UpcFormat.UPC_E,
-                payload="0425261",
                 number_system_digit=0,
+                payload="0425261",
                 check_digit=4,
             ),
         ),
@@ -36,8 +36,8 @@ def test_parse_upc_a() -> None:
             Upc(
                 value="1425261",
                 format=UpcFormat.UPC_E,
-                payload="1425261",
                 number_system_digit=1,
+                payload="1425261",
                 check_digit=1,
             ),
         ),
@@ -46,8 +46,8 @@ def test_parse_upc_a() -> None:
             Upc(
                 value="14252611",
                 format=UpcFormat.UPC_E,
-                payload="1425261",
                 number_system_digit=1,
+                payload="1425261",
                 check_digit=1,
             ),
         ),


### PR DESCRIPTION
Biip already supports UPC-A since it is also a valid GTIN-12.

This PR adds extended support for UPC-A and UPC-E, including suppression of
UPC-A to UPC-E and expansion of UPC-E to UPC-A.

Fixes #77
