### PR TITLE
Allow unknown GS1 prefixes

### DIFF
--- a/src/biip/gs1/_prefixes.py
+++ b/src/biip/gs1/_prefixes.py
@@ -3,6 +3,7 @@
 import json
 import pathlib
 from dataclasses import dataclass
+from typing import Optional
 
 from biip import ParseError
 
@@ -33,14 +34,14 @@ class GS1Prefix:
     usage: str
 
     @classmethod
-    def extract(cls, value: str) -> "GS1Prefix":
+    def extract(cls, value: str) -> Optional["GS1Prefix"]:
         """Extract the GS1 Prefix from the given value.
 
         Args:
             value: The string to extract a GS1 Prefix from.
 
         Returns:
-            Metadata about the extracted prefix.
+            Metadata about the extracted prefix, or `None` if the prefix is unknown.
 
         Raises:
             ParseError: If the parsing fails.
@@ -55,7 +56,12 @@ class GS1Prefix:
             if prefix_range.min_value <= number <= prefix_range.max_value:
                 return cls(value=prefix, usage=prefix_range.usage)
 
-        raise ParseError(f"Failed to get GS1 Prefix from {value!r}.")
+        if not prefix.isnumeric():
+            # `prefix` is now the shortest prefix possible, and should be
+            # numeric even if the prefix assignment is unknown.
+            raise ParseError(f"Failed to get GS1 Prefix from {value!r}.")
+
+        return None
 
 
 @dataclass(frozen=True)

--- a/src/biip/gtin/_gtin.py
+++ b/src/biip/gtin/_gtin.py
@@ -25,7 +25,7 @@ class Gtin:
 
     #: The GS1 prefix, indicating what GS1 country organization that assigned
     #: code range.
-    prefix: GS1Prefix
+    prefix: Optional[GS1Prefix]
 
     #: The actual payload, including packaging level if any, company prefix,
     #: and item reference. Excludes the check digit.
@@ -105,7 +105,7 @@ class Gtin:
             )
 
         gtin_type: Type[Union[Gtin, Rcn]]
-        if "Restricted Circulation Number" in prefix.usage:
+        if prefix is not None and "Restricted Circulation Number" in prefix.usage:
             gtin_type = Rcn
         else:
             gtin_type = Gtin

--- a/src/biip/gtin/_rcn.py
+++ b/src/biip/gtin/_rcn.py
@@ -53,6 +53,10 @@ class Rcn(Gtin):
         self._set_usage()
 
     def _set_usage(self) -> None:
+        # Classification as RCN depends on the prefix being known, so we won't
+        # get here unless it is known.
+        assert self.prefix is not None
+
         if "within a geographic region" in self.prefix.usage:
             self.usage = RcnUsage.GEOGRAPHICAL
         if "within a company" in self.prefix.usage:

--- a/src/biip/sscc.py
+++ b/src/biip/sscc.py
@@ -41,7 +41,7 @@ class Sscc:
 
     #: The GS1 prefix, indicating what GS1 country organization that assigned
     #: code range.
-    prefix: GS1Prefix
+    prefix: Optional[GS1Prefix]
 
     #: Extension digit used to increase the capacity of the serial reference.
     extension_digit: int
@@ -118,6 +118,10 @@ class Sscc:
             A human-readable string where the logic parts are separated by whitespace.
         """
         value = self.payload[1:]  # Strip extension digit
+
+        if self.prefix is None:
+            return f"{self.extension_digit} {value} {self.check_digit}"
+
         gs1_prefix = self.prefix.value
 
         if company_prefix_length is None:

--- a/tests/gs1/test_prefixes.py
+++ b/tests/gs1/test_prefixes.py
@@ -6,7 +6,7 @@ from biip import ParseError
 from biip.gs1 import GS1Prefix
 
 
-@pytest.mark.parametrize("bad_value", ["abcdef", "199999"])
+@pytest.mark.parametrize("bad_value", ["abcdef", "1a2b3c"])
 def test_invalid_gs1_prefix(bad_value: str) -> None:
     with pytest.raises(ParseError) as exc_info:
         GS1Prefix.extract(bad_value)
@@ -23,6 +23,7 @@ def test_invalid_gs1_prefix(bad_value: str) -> None:
         ),
         ("060999", GS1Prefix(value="060", usage="GS1 US")),
         ("139999", GS1Prefix(value="139", usage="GS1 US")),
+        ("6712670000276", None),  # Unassigned prefix
         ("701999", GS1Prefix(value="701", usage="GS1 Norway")),
         ("978-1-492-05374-3", GS1Prefix(value="978", usage="Bookland (ISBN)")),
     ],

--- a/tests/gtin/test_parse.py
+++ b/tests/gtin/test_parse.py
@@ -196,3 +196,13 @@ def test_parse_gtin_14() -> None:
         check_digit=3,
         packaging_level=9,
     )
+
+
+def test_parse_gtin_with_unknown_gs1_prefix() -> None:
+    assert Gtin.parse("6712670000276") == Gtin(
+        value="6712670000276",
+        format=GtinFormat.GTIN_13,
+        prefix=None,
+        payload="671267000027",
+        check_digit=6,
+    )

--- a/tests/test_sscc.py
+++ b/tests/test_sscc.py
@@ -73,6 +73,13 @@ def test_as_hri(prefix_length: Optional[int], expected: str) -> None:
     assert sscc.as_hri(company_prefix_length=prefix_length) == expected
 
 
+def test_as_hri_with_unknown_gs1_prefix() -> None:
+    # GS1 prefix 671 is currently unassigned.
+    sscc = Sscc.parse("367130321109103428")
+
+    assert sscc.as_hri() == "3 6713032110910342 8"
+
+
 def test_as_hri_with_too_low_company_prefix_length() -> None:
     sscc = Sscc.parse("376130321109103420")
 


### PR DESCRIPTION
This is a **breaking change** to Biip's API.

With these changes, we allow for GS1 prefixes to be unknown, e.g. `None`,
instead of raising a `ParseError` if we're not able to identify the GS1 prefix.
This makes it possible to validate that e.g. a GTIN is otherwise valid, e.g.
has a valid checksum, even if the prefix is unknown to Biip. If your
application needs to validate the GS1 prefix too, simply check if the `prefix`
attribute is set or `None`.

Fixes #93
