### PR TITLE
Never interpret GTIN-14 as RCN

### DIFF
--- a/src/biip/gtin/_gtin.py
+++ b/src/biip/gtin/_gtin.py
@@ -105,7 +105,11 @@ class Gtin:
             )
 
         gtin_type: Type[Union[Gtin, Rcn]]
-        if prefix is not None and "Restricted Circulation Number" in prefix.usage:
+        if (
+            gtin_format <= GtinFormat.GTIN_13
+            and prefix is not None
+            and "Restricted Circulation Number" in prefix.usage
+        ):
             gtin_type = Rcn
         else:
             gtin_type = Gtin

--- a/src/biip/gtin/_rcn.py
+++ b/src/biip/gtin/_rcn.py
@@ -18,14 +18,20 @@ except ImportError:  # pragma: no cover
 class Rcn(Gtin):
     """Restricted Circulation Number (RCN) is a subset of GTIN.
 
-    RCNs with prefix 02 and 20-29 have the same semantics across a geographic
+    Both RCN-8, RCN-12, and RCN-13 are supported. There is no 14 digit version
+    of RCN.
+
+    RCNs with GS1 Prefix 02 or 20-29 have the same semantics across a geographic
     region, defined by the local GS1 Member Organization.
 
-    RCNs with prefix 40-49 have semantics that are only defined within a
-    single company.
+    RCNs with GS1 Prefix 04 or 40-49 have semantics that are only defined within
+    a single company.
 
     Use :meth:`biip.gtin.Gtin.parse` to parse potential RCNs. This subclass
     is returned if the GS1 Prefix signifies that the value is an RCN.
+
+    References:
+        GS1 General Specifications, section 2.1.11-2.1.12
     """
 
     #: Where the RCN can be circulated,

--- a/tests/gtin/test_rcn.py
+++ b/tests/gtin/test_rcn.py
@@ -50,6 +50,15 @@ def test_rcn_without_specified_region() -> None:
     assert rcn.money is None
 
 
+def test_gtin_14_with_rcn_prefix_is_not_an_rcn() -> None:
+    # The value below is a GTIN-14 composed of packaging level 1 and a valid RCN-13.
+    gtin = Gtin.parse("12991111111110", rcn_region=None)
+
+    assert isinstance(gtin, Gtin)
+    assert not isinstance(gtin, Rcn)
+    assert gtin.format == GtinFormat.GTIN_14
+
+
 @pytest.mark.parametrize(
     "rcn_region, value, weight, price, money",
     [


### PR DESCRIPTION
RCN is only defined for the lenghts 8, 12, and 13. Even though a GTIN-14
might be constructed with a GS1 Prefix in the RCN ranges, we should not
interpret it as a RCN.
