### PR TITLE
Remove the deprecated Baltics RCN region

### DIFF
--- a/src/biip/gtin/_enums.py
+++ b/src/biip/gtin/_enums.py
@@ -53,12 +53,6 @@ class RcnRegion(Enum):
     The value of the enum is the lowercase ISO 3166-1 Alpha-2 code.
     """
 
-    #: Baltics (Estonia, Latvia, Lithuania)
-    #:
-    #: Deprecated:
-    #:   Use `ESTONIA`, `LATVIA`, or `LITHUANIA` instead.
-    BALTICS = "baltics"
-
     #: Estonia
     ESTONIA = "ee"
 

--- a/src/biip/gtin/_rcn.py
+++ b/src/biip/gtin/_rcn.py
@@ -256,11 +256,6 @@ _weight_from_pppp = _RcnStrategy(
 )
 
 _RCN_RULES: Dict[RcnRegion, Dict[str, _RcnStrategy]] = {
-    RcnRegion.BALTICS: {
-        "23": _weight_from_pppp,
-        "24": _weight_from_pppp,
-        "25": _weight_from_pppp,
-    },
     RcnRegion.ESTONIA: {
         "23": _weight_from_pppp,
         "24": _weight_from_pppp,


### PR DESCRIPTION
Use `ESTONIA`, `LATVIA`, or `LITHUANIA` instead.
