### PR TITLE
Remove Python 3.6 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
 
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ see the [documentation](https://biip.readthedocs.io/).
 
 ## Installation
 
-Biip requires Python 3.6 or newer.
+Biip requires Python 3.7 or newer.
 
 Biip is available from [PyPI](https://pypi.org/project/biip/):
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ For details on how the barcode data is interpreted, please refer to the
 Installation
 ============
 
-Biip requires Python 3.6 or newer.
+Biip requires Python 3.7 or newer.
 
 Biip is available from `PyPI <https://pypi.org/project/biip/>`_:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -6,7 +6,7 @@ package = "biip"
 locations = ["src", "tests", "noxfile.py", "docs/conf.py"]
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
 def tests(session):
     """Run the test suite."""
     args = session.posargs or ["--cov"]
@@ -14,7 +14,7 @@ def tests(session):
     session.run("pytest", *args)
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
 def flake8(session):
     """Lint using flake8."""
     args = session.posargs or locations
@@ -30,7 +30,7 @@ def flake8(session):
     session.run("flake8", *args)
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
+@nox.session(python=["3.7", "3.8", "3.9", "3.10"])
 def mypy(session):
     """Type-check using mypy."""
     args = session.posargs or locations

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,12 +13,10 @@ classifiers = [
    "Development Status :: 5 - Production/Stable",
    "Intended Audience :: Developers",
    "Topic :: Software Development :: Libraries",
-   "Programming Language :: Python :: 3.6",  # Not automatically added because we require >= 3.6.2
 ]
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
-dataclasses = {version = "^0.8", python = ">=3.6,<3.7"}
+python = "^3.7.0"
 importlib_metadata = {version = ">=1.6,<5.0", python = "<3.8"}
 py-moneyed = {version = ">=0.8", optional = true}
 
@@ -46,7 +44,6 @@ pytest-cov = "^3.0.0"
 sphinx = "^4.0.0"
 sphinx-rtd-theme = "^1.0.0"
 sphinx-autodoc-typehints = "^1.12.0"
-types-dataclasses = {version = "^0.6.0", python = ">=3.6,<3.7"}
 xdoctest = "^0.15.0"
 
 [tool.black]

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -1,5 +1,7 @@
 """The top-level Biip parser."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Callable, Iterable, List, Optional, Tuple
 
@@ -18,7 +20,7 @@ def parse(
     *,
     rcn_region: Optional[RcnRegion] = None,
     separator_chars: Iterable[str] = DEFAULT_SEPARATOR_CHARS,
-) -> "ParseResult":
+) -> ParseResult:
     """Identify data format and parse data.
 
     The current strategy is:

--- a/src/biip/gln.py
+++ b/src/biip/gln.py
@@ -25,6 +25,8 @@ using the :class:`Gln` class.
    usage='GS1 US'), payload='123456789012', check_digit=8)
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 
@@ -52,7 +54,7 @@ class Gln:
     check_digit: int
 
     @classmethod
-    def parse(cls, value: str) -> "Gln":
+    def parse(cls, value: str) -> Gln:
         """Parse the given value into a :class:`Gln` object.
 
         Args:

--- a/src/biip/gs1/_application_identifiers.py
+++ b/src/biip/gs1/_application_identifiers.py
@@ -1,5 +1,7 @@
 """GS1 Application Identifiers."""
 
+from __future__ import annotations
+
 import json
 import pathlib
 from dataclasses import dataclass, field
@@ -52,7 +54,7 @@ class GS1ApplicationIdentifier:
     pattern: str = field(repr=False)
 
     @classmethod
-    def extract(cls, value: str) -> "GS1ApplicationIdentifier":
+    def extract(cls, value: str) -> GS1ApplicationIdentifier:
         """Extract the GS1 Application Identifier (AI) from the given value.
 
         Args:

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -1,5 +1,7 @@
 """GS1 Element Strings."""
 
+from __future__ import annotations
+
 import calendar
 import datetime
 import re
@@ -79,7 +81,7 @@ class GS1ElementString:
         *,
         rcn_region: Optional[RcnRegion] = None,
         separator_chars: Iterable[str] = DEFAULT_SEPARATOR_CHARS,
-    ) -> "GS1ElementString":
+    ) -> GS1ElementString:
         """Extract the first GS1 Element String from the given value.
 
         Args:

--- a/src/biip/gs1/_messages.py
+++ b/src/biip/gs1/_messages.py
@@ -1,5 +1,7 @@
 """GS1 messages."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Iterable, List, Optional, Union
 
@@ -31,7 +33,7 @@ class GS1Message:
         *,
         rcn_region: Optional[RcnRegion] = None,
         separator_chars: Iterable[str] = DEFAULT_SEPARATOR_CHARS,
-    ) -> "GS1Message":
+    ) -> GS1Message:
         """Parse a string from a barcode scan as a GS1 message with AIs.
 
         Args:

--- a/src/biip/gs1/_prefixes.py
+++ b/src/biip/gs1/_prefixes.py
@@ -1,5 +1,7 @@
 """Barcode prefixes allocated by GS1."""
 
+from __future__ import annotations
+
 import json
 import pathlib
 from dataclasses import dataclass
@@ -34,7 +36,7 @@ class GS1Prefix:
     usage: str
 
     @classmethod
-    def extract(cls, value: str) -> Optional["GS1Prefix"]:
+    def extract(cls, value: str) -> Optional[GS1Prefix]:
         """Extract the GS1 Prefix from the given value.
 
         Args:

--- a/src/biip/gs1/_symbology.py
+++ b/src/biip/gs1/_symbology.py
@@ -1,5 +1,7 @@
 """Symbology Identifiers relevant to the GS1 system."""
 
+from __future__ import annotations
+
 from enum import Enum
 from typing import Set
 
@@ -52,7 +54,7 @@ class GS1Symbology(Enum):
     GS1_DOTCODE = "J1"
 
     @classmethod
-    def with_ai_element_strings(cls) -> Set["GS1Symbology"]:
+    def with_ai_element_strings(cls) -> Set[GS1Symbology]:
         """Symbologies that may contain AI Element Strings."""
         return {
             cls.GS1_128,
@@ -63,7 +65,7 @@ class GS1Symbology(Enum):
         }
 
     @classmethod
-    def with_gtin(cls) -> Set["GS1Symbology"]:
+    def with_gtin(cls) -> Set[GS1Symbology]:
         """Symbologies that may contain GTINs."""
         return {cls.EAN_13, cls.EAN_13_WITH_ADD_ON, cls.EAN_8, cls.ITF_14}
 

--- a/src/biip/gtin/_enums.py
+++ b/src/biip/gtin/_enums.py
@@ -1,5 +1,7 @@
 """Enums used when parsing GTINs."""
 
+from __future__ import annotations
+
 from enum import Enum, IntEnum
 from typing import Optional, Union
 
@@ -75,9 +77,7 @@ class RcnRegion(Enum):
     SWEDEN = "se"
 
     @classmethod
-    def from_iso_3166_1_numeric_code(
-        cls, code: Union[int, str]
-    ) -> Optional["RcnRegion"]:
+    def from_iso_3166_1_numeric_code(cls, code: Union[int, str]) -> Optional[RcnRegion]:
         """Get the region from an ISO 3166-1 numeric code."""
         code = str(code).zfill(3)
 

--- a/src/biip/gtin/_gtin.py
+++ b/src/biip/gtin/_gtin.py
@@ -1,5 +1,7 @@
 """Global Trade Item Number (GTIN)."""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional, Type, Union
 
@@ -42,7 +44,7 @@ class Gtin:
     packaging_level: Optional[int] = None
 
     @classmethod
-    def parse(cls, value: str, *, rcn_region: Optional[RcnRegion] = None) -> "Gtin":
+    def parse(cls, value: str, *, rcn_region: Optional[RcnRegion] = None) -> Gtin:
         """Parse the given value into a :class:`Gtin` object.
 
         Both GTIN-8, GTIN-12, GTIN-13, and GTIN-14 are supported.
@@ -149,7 +151,7 @@ class Gtin:
             raise EncodeError(f"Failed encoding {self.value!r} as {gtin_format!s}.")
         return f"{self.payload}{self.check_digit}".zfill(gtin_format.length)
 
-    def without_variable_measure(self) -> "Gtin":
+    def without_variable_measure(self) -> Gtin:
         """Create a new GTIN where the variable measure is zeroed out.
 
         This method is a no-op for proper GTINs. For RCNs, see the method on the

--- a/src/biip/sscc.py
+++ b/src/biip/sscc.py
@@ -24,6 +24,8 @@ Biip can format the SSCC in HRI format for printing on a label.
     '3 761 30321 10910342 0'
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from typing import Optional
 
@@ -54,7 +56,7 @@ class Sscc:
     check_digit: int
 
     @classmethod
-    def parse(cls, value: str) -> "Sscc":
+    def parse(cls, value: str) -> Sscc:
         """Parse the given value into a :class:`Sscc` object.
 
         Args:

--- a/src/biip/symbology.py
+++ b/src/biip/symbology.py
@@ -22,6 +22,8 @@ References:
     ISO/IEC 15424:2008.
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
@@ -156,7 +158,7 @@ class SymbologyIdentifier:
     gs1_symbology: Optional[GS1Symbology] = None
 
     @classmethod
-    def extract(cls, value: str) -> "SymbologyIdentifier":
+    def extract(cls, value: str) -> SymbologyIdentifier:
         """Extract the Symbology Identifier from the given value.
 
         Args:

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -47,6 +47,8 @@ The canonical format for persisting UPCs to e.g. a database is GTIN-14.
     '00042100005264'
 """
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 from enum import Enum
 from typing import Optional
@@ -89,7 +91,7 @@ class Upc:
     check_digit: Optional[int] = None
 
     @classmethod
-    def parse(cls, value: str) -> "Upc":
+    def parse(cls, value: str) -> Upc:
         """Parse the given value into a :class:`Upc` object.
 
         Args:
@@ -124,7 +126,7 @@ class Upc:
         raise Exception("Unhandled UPC length. This is a bug.")  # pragma: no cover
 
     @classmethod
-    def _parse_upc_a(cls, value: str) -> "Upc":
+    def _parse_upc_a(cls, value: str) -> Upc:
         assert len(value) == 12
 
         payload = value[:-1]
@@ -147,7 +149,7 @@ class Upc:
         )
 
     @classmethod
-    def _parse_upc_e(cls, value: str) -> "Upc":
+    def _parse_upc_e(cls, value: str) -> Upc:
         length = len(value)
         assert length in (6, 7, 8)
 


### PR DESCRIPTION
- Require Python 3.7, as 3.6 has reached end-of-life
- Use lazy annotations instead of strings
