### PR TITLE
Deprecate from_iso_3166_1_numeric_code()

### DIFF
--- a/scripts/download_gs1_ai.py
+++ b/scripts/download_gs1_ai.py
@@ -50,7 +50,6 @@ def parse(html_content: bytes) -> List[GS1ApplicationIdentifier]:
 
 def _fix_data_title(value: str) -> str:
     """Remove HTML elements from the data title."""
-
     if "<sup>" in value:
         value = value.replace("<sup>", "")
     if "</sup>" in value:
@@ -61,7 +60,6 @@ def _fix_data_title(value: str) -> str:
 
 def _fix_pattern(value: str) -> str:
     """Fix regular expression metacharacters that are missing their slash prefix."""
-
     if r"(d" in value:
         value = value.replace(r"(d", r"(\d")
 

--- a/src/biip/gtin/_enums.py
+++ b/src/biip/gtin/_enums.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from enum import Enum, IntEnum
 from typing import Optional, Union
 
@@ -84,7 +85,27 @@ class RcnRegion(Enum):
 
     @classmethod
     def from_iso_3166_1_numeric_code(cls, code: Union[int, str]) -> Optional[RcnRegion]:
-        """Get the region from an ISO 3166-1 numeric code."""
+        """Get the region from an ISO 3166-1 numeric code.
+
+        Args:
+            code: The ISO 3166-1 numeric code.
+
+        Returns:
+            The RCN region or ``None`` if the code does not match a RCN region
+            known to Biip.
+
+        Raises:
+            ValueError: If the code is not a valid ISO 3166-1 numeric code.
+
+        Deprecated:
+            This method was deprecated in Biip 2.2. It will be removed in Biip 3.0.
+        """
+        warnings.warn(
+            "The method from_iso_3166_1_numeric_code() is deprecated "
+            "and will be removed in Biip 3.0.",
+            DeprecationWarning,
+        )
+
         code = str(code).zfill(3)
 
         if len(code) != 3 or not code.isnumeric():

--- a/tests/gtin/test_rcn.py
+++ b/tests/gtin/test_rcn.py
@@ -112,14 +112,17 @@ def test_fails_when_rcn_region_is_unknown_string() -> None:
         (8, None),  # Albania, once supported by Biip.
     ],
 )
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_rcn_region_lookup_by_iso_3166_1_numeric_code(
     value: Union[int, str], rcn_region: RcnRegion
 ) -> None:
-    result = RcnRegion.from_iso_3166_1_numeric_code(value)
+    with pytest.deprecated_call(match="will be removed in Biip 3.0"):
+        result = RcnRegion.from_iso_3166_1_numeric_code(value)
 
     assert result == rcn_region
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_fails_when_iso_3166_1_code_is_too_long() -> None:
     with pytest.raises(ValueError) as exc_info:
         RcnRegion.from_iso_3166_1_numeric_code("1234")
@@ -130,6 +133,7 @@ def test_fails_when_iso_3166_1_code_is_too_long() -> None:
     )
 
 
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_fails_when_iso_3166_1_code_is_unknown_string() -> None:
     with pytest.raises(ValueError) as exc_info:
         RcnRegion.from_iso_3166_1_numeric_code("foo")


### PR DESCRIPTION
This method is out of scope for Biip. It is better replaced with e.g. pycountry.
