### PR TITLE
Fix .without_variable_measure() for 14-digit RCNs

### DIFF
--- a/src/biip/gtin/_rcn.py
+++ b/src/biip/gtin/_rcn.py
@@ -214,10 +214,11 @@ class _Strategy:
         # Zero out the variable measure part of the payload, and recalculate both
         # the GTIN check digit and the variable measure's check digit digit, if any.
 
-        zeroed_value = "0" * len(rcn.value[self.value_slice])
+        rcn_13 = rcn.as_gtin_13()
+        zeroed_value = "0" * len(rcn_13[self.value_slice])
 
         digits = list(self.pattern)
-        digits[self.prefix_slice] = list(rcn.value[self.prefix_slice])
+        digits[self.prefix_slice] = list(rcn_13[self.prefix_slice])
         digits[self.value_slice] = list(zeroed_value)
         if self.check_digit_slice is not None:
             digits[self.check_digit_slice] = [

--- a/tests/gtin/test_without_variable_measure.py
+++ b/tests/gtin/test_without_variable_measure.py
@@ -10,7 +10,8 @@ from biip.gtin import Gtin, Rcn, RcnRegion
 @pytest.mark.parametrize(
     "rcn_region, value, expected",
     [
-        (RcnRegion.DENMARK, "2712341002251", "2712341000004"),
+        (RcnRegion.DENMARK, "2712341002251", "2712341000004"),  # GTIN-13
+        (RcnRegion.DENMARK, "02712341002251", "2712341000004"),  # GTIN-14
         (RcnRegion.ESTONIA, "2311111112345", "2311111100007"),
         (RcnRegion.FINLAND, "2311111112345", "2311111100007"),
         (RcnRegion.GREAT_BRITAIN, "2011122912346", "2011122000005"),
@@ -29,7 +30,7 @@ def test_without_variable_measure_strips_variable_parts(
     stripped_rcn = original_rcn.without_variable_measure()
 
     assert isinstance(stripped_rcn, Rcn)
-    assert stripped_rcn.value == expected
+    assert stripped_rcn.as_gtin_13() == expected
     assert stripped_rcn.region == original_rcn.region
 
 
@@ -93,8 +94,10 @@ def test_without_variable_measure_keeps_nonvariable_rcn_unchanged(
 @pytest.mark.parametrize(
     "rcn_region, value",
     [
-        (RcnRegion.NORWAY, "00012348"),
-        (RcnRegion.NORWAY, "0412345678903"),
+        (RcnRegion.NORWAY, "00012348"),  # GTIN-8
+        (RcnRegion.NORWAY, "412345678903"),  # GTIN-12
+        (RcnRegion.NORWAY, "0412345678903"),  # GTIN-13
+        (RcnRegion.NORWAY, "00412345678903"),  # GTIN-14
     ],
 )
 def test_without_variable_measure_keeps_company_rcn_unchanged(


### PR DESCRIPTION
This bug was introduced in Biip 2.2.0.
