### PR TITLE
Raise `ParseError` if input is numeric but not decimal

### DIFF
--- a/src/biip/gln.py
+++ b/src/biip/gln.py
@@ -75,7 +75,7 @@ class Gln:
                 f"Expected 13 digits, got {len(value)}."
             )
 
-        if not value.isnumeric():
+        if not value.isdecimal():
             raise ParseError(
                 f"Failed to parse {value!r} as GLN: Expected a numerical value."
             )

--- a/src/biip/gs1/_prefixes.py
+++ b/src/biip/gs1/_prefixes.py
@@ -51,14 +51,14 @@ class GS1Prefix:
         for prefix_range in _GS1_PREFIX_RANGES:
             prefix = value[: prefix_range.length]
 
-            if not prefix.isnumeric():
+            if not prefix.isdecimal():
                 continue
             number = int(prefix)
 
             if prefix_range.min_value <= number <= prefix_range.max_value:
                 return cls(value=prefix, usage=prefix_range.usage)
 
-        if not prefix.isnumeric():
+        if not prefix.isdecimal():
             # `prefix` is now the shortest prefix possible, and should be
             # numeric even if the prefix assignment is unknown.
             raise ParseError(f"Failed to get GS1 Prefix from {value!r}.")

--- a/src/biip/gs1/checksums.py
+++ b/src/biip/gs1/checksums.py
@@ -25,7 +25,7 @@ def numeric_check_digit(value: str) -> int:
         >>> numeric_check_digit("9501234")  # GTIN-8
         6
     """
-    if not value.isnumeric():
+    if not value.isdecimal():
         raise ValueError(f"Expected numeric value, got {value!r}.")
 
     digits = list(map(int, list(value)))
@@ -60,7 +60,7 @@ def price_check_digit(value: str) -> int:
         >>> price_check_digit("14685")
         6
     """
-    if not value.isnumeric():
+    if not value.isdecimal():
         raise ValueError(f"Expected numeric value, got {value!r}.")
 
     if len(value) == 4:

--- a/src/biip/gtin/_enums.py
+++ b/src/biip/gtin/_enums.py
@@ -108,7 +108,7 @@ class RcnRegion(Enum):
 
         code = str(code).zfill(3)
 
-        if len(code) != 3 or not code.isnumeric():
+        if len(code) != 3 or not code.isdecimal():
             raise ValueError(
                 f"Expected ISO 3166-1 numeric code to be 3 digits, got {code!r}."
             )

--- a/src/biip/gtin/_gtin.py
+++ b/src/biip/gtin/_gtin.py
@@ -72,7 +72,7 @@ class Gtin:
                 f"Expected 8, 12, 13, or 14 digits, got {len(value)}."
             )
 
-        if not value.isnumeric():
+        if not value.isdecimal():
             raise ParseError(
                 f"Failed to parse {value!r} as GTIN: Expected a numerical value."
             )

--- a/src/biip/sscc.py
+++ b/src/biip/sscc.py
@@ -77,7 +77,7 @@ class Sscc:
                 f"Expected 18 digits, got {len(value)}."
             )
 
-        if not value.isnumeric():
+        if not value.isdecimal():
             raise ParseError(
                 f"Failed to parse {value!r} as SSCC: Expected a numerical value."
             )

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -113,7 +113,7 @@ class Upc:
                 f"Expected 6, 7, 8, or 12 digits, got {length}."
             )
 
-        if not value.isnumeric():
+        if not value.isdecimal():
             raise ParseError(
                 f"Failed to parse {value!r} as UPC: Expected a numerical value."
             )
@@ -261,7 +261,7 @@ class Upc:
 
 def _upc_e_to_upc_a_expansion(value: str) -> str:
     assert len(value) == 8
-    assert value.isnumeric()
+    assert value.isdecimal()
 
     last_digit = int(value[6])
     check_digit = int(value[7])
@@ -285,7 +285,7 @@ def _upc_e_to_upc_a_expansion(value: str) -> str:
 
 def _upc_a_to_upc_e_suppression(value: str) -> str:
     assert len(value) == 12
-    assert value.isnumeric()
+    assert value.isdecimal()
 
     check_digit = int(value[11])
 

--- a/tests/gs1/test_checksums.py
+++ b/tests/gs1/test_checksums.py
@@ -3,11 +3,12 @@ import pytest
 from biip.gs1.checksums import numeric_check_digit, price_check_digit
 
 
-def test_numeric_check_digit_with_nonnumeric_value() -> None:
+@pytest.mark.parametrize("value", ["abc", "⁰⁰⁰"])
+def test_numeric_check_digit_with_nonnumeric_value(value: str) -> None:
     with pytest.raises(ValueError) as exc_info:
-        numeric_check_digit("abc")
+        numeric_check_digit(value)
 
-    assert str(exc_info.value) == "Expected numeric value, got 'abc'."
+    assert str(exc_info.value) == f"Expected numeric value, got {value!r}."
 
 
 @pytest.mark.parametrize(
@@ -29,11 +30,12 @@ def test_numeric_check_digit(value: str, expected: int) -> None:
     assert numeric_check_digit(value) == expected
 
 
-def test_price_check_digit_with_nonnumeric_value() -> None:
+@pytest.mark.parametrize("value", ["abc", "⁰⁰⁰"])
+def test_price_check_digit_with_nonnumeric_value(value: str) -> None:
     with pytest.raises(ValueError) as exc_info:
-        price_check_digit("abc")
+        price_check_digit(value)
 
-    assert str(exc_info.value) == "Expected numeric value, got 'abc'."
+    assert str(exc_info.value) == f"Expected numeric value, got {value!r}."
 
 
 @pytest.mark.parametrize(

--- a/tests/gs1/test_element_strings.py
+++ b/tests/gs1/test_element_strings.py
@@ -243,7 +243,7 @@ def test_extract_amount_payable(value: str, expected: Decimal) -> None:
         ("39117101230", "ZAR", Decimal("123.0")),
         ("391097812301", "EUR", Decimal("12301")),
         #
-        # Amount payable for variable mesure trade item and currency (section 3.6.9)
+        # Amount payable for variable measure trade item and currency (section 3.6.9)
         ("39327101230", "ZAR", Decimal("12.30")),
         ("39317101230", "ZAR", Decimal("123.0")),
         ("393097812301", "EUR", Decimal("12301")),

--- a/tests/gtin/test_parse.py
+++ b/tests/gtin/test_parse.py
@@ -17,13 +17,14 @@ def test_parse_value_with_invalid_length() -> None:
     )
 
 
-def test_parse_nonnumeric_value() -> None:
+@pytest.mark.parametrize("value", ["0123456789abc", "0123456789⁰⁰⁰"])
+def test_parse_nonnumeric_value(value: str) -> None:
     with pytest.raises(ParseError) as exc_info:
-        Gtin.parse("0123456789abc")
+        Gtin.parse(value)
 
     assert (
         str(exc_info.value)
-        == "Failed to parse '0123456789abc' as GTIN: Expected a numerical value."
+        == f"Failed to parse {value!r} as GTIN: Expected a numerical value."
     )
 
 

--- a/tests/test_gln.py
+++ b/tests/test_gln.py
@@ -34,13 +34,14 @@ def test_parse_value_with_invalid_length() -> None:
     )
 
 
-def test_parse_nonnumeric_value() -> None:
+@pytest.mark.parametrize("value", ["123456789o128", "123456789⁰128"])
+def test_parse_nonnumeric_value(value: str) -> None:
     with pytest.raises(ParseError) as exc_info:
-        Gln.parse("123456789o128")
+        Gln.parse(value)
 
     assert (
         str(exc_info.value)
-        == "Failed to parse '123456789o128' as GLN: Expected a numerical value."
+        == f"Failed to parse {value!r} as GLN: Expected a numerical value."
     )
 
 

--- a/tests/test_sscc.py
+++ b/tests/test_sscc.py
@@ -37,13 +37,14 @@ def test_parse_value_with_invalid_length() -> None:
     )
 
 
-def test_parse_nonnumeric_value() -> None:
+@pytest.mark.parametrize("value", ["012345678901234abc", "012345678901234⁰⁰⁰"])
+def test_parse_nonnumeric_value(value: str) -> None:
     with pytest.raises(ParseError) as exc_info:
-        Sscc.parse("012345678901234abc")
+        Sscc.parse(value)
 
     assert (
         str(exc_info.value)
-        == "Failed to parse '012345678901234abc' as SSCC: Expected a numerical value."
+        == f"Failed to parse {value!r} as SSCC: Expected a numerical value."
     )
 
 

--- a/tests/upc/test_parse.py
+++ b/tests/upc/test_parse.py
@@ -67,13 +67,14 @@ def test_parse_value_with_invalid_length() -> None:
     )
 
 
-def test_parse_nonnumeric_value() -> None:
+@pytest.mark.parametrize("value", ["012345678abc", "012345678⁰⁰⁰"])
+def test_parse_nonnumeric_value(value: str) -> None:
     with pytest.raises(ParseError) as exc_info:
-        Upc.parse("012345678abc")
+        Upc.parse(value)
 
     assert (
         str(exc_info.value)
-        == "Failed to parse '012345678abc' as UPC: Expected a numerical value."
+        == f"Failed to parse {value!r} as UPC: Expected a numerical value."
     )
 
 


### PR DESCRIPTION
This fixes crashes on input like `1234⁰⁰⁰`, which is numeric, but not decimal, and thus cannot be converted to an integer.