### PR TITLE
parse_hri() error handling and RCN support

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Please open an issue if you have any barcode parsing related needs that are not 
       parse amounts with currency into `Money` values.
   - Encode as Human Readable Interpretation (HRI),
     e.g. with parenthesis around the AI numbers.
+  - Parse Human Readable Interpretation (HRI) strings.
   - Easy lookup of parsed Element Strings by:
     - Application Identifier (AI) prefix
     - Part of AI's data title

--- a/src/biip/gs1/__init__.py
+++ b/src/biip/gs1/__init__.py
@@ -69,11 +69,13 @@ methods to lookup element strings either by the Application Identifier's
 
 from typing import Tuple
 
+ASCII_GROUP_SEPARATOR = "\x1d"
+
 #: The default separator character is <GS>, ASCII value 29.
 #:
 #: References:
 #:   GS1 General Specifications, section 7.8.3.
-DEFAULT_SEPARATOR_CHARS: Tuple[str] = ("\x1d",)
+DEFAULT_SEPARATOR_CHARS: Tuple[str] = (ASCII_GROUP_SEPARATOR,)
 
 # The following must be imported in this specific order.
 from biip.gs1._symbology import GS1Symbology  # isort:skip  # noqa: E402

--- a/src/biip/gs1/_messages.py
+++ b/src/biip/gs1/_messages.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from itertools import chain
 from typing import Iterable, List, Optional, Union
 
 from biip import ParseError
@@ -115,16 +116,17 @@ class GS1Message:
                 )
             pairs.append((_GS1_APPLICATION_IDENTIFIERS[ai_number], ai_data))
 
-        normalized_string = "".join(
-            "".join(
+        parts = chain(
+            *[
                 [
-                    gs1ai.ai,
-                    value,
-                    (ASCII_GROUP_SEPARATOR if gs1ai.fnc1_required else ""),
+                    gs1_ai.ai,
+                    ai_data,
+                    (ASCII_GROUP_SEPARATOR if gs1_ai.fnc1_required else ""),
                 ]
-            )
-            for gs1ai, value in pairs
+                for gs1_ai, ai_data in pairs
+            ]
         )
+        normalized_string = "".join(parts)
         return GS1Message.parse(normalized_string)
 
     def as_hri(self) -> str:

--- a/src/biip/gs1/_messages.py
+++ b/src/biip/gs1/_messages.py
@@ -87,11 +87,19 @@ class GS1Message:
         return cls(value=value, element_strings=element_strings)
 
     @classmethod
-    def parse_hri(cls, value: str) -> GS1Message:
+    def parse_hri(
+        cls,
+        value: str,
+        *,
+        rcn_region: Optional[RcnRegion] = None,
+    ) -> GS1Message:
         """Parse the GS1 string given in HRI (human readable interpretation) format.
 
         Args:
-            value: The GS1 string to parse.
+            value: The HRI string to parse.
+            rcn_region: The geographical region whose rules should be used to
+                interpret Restricted Circulation Numbers (RCN).
+                Needed to extract e.g. variable weight/price from GTIN.
 
         Returns:
             A message object with one or more element strings.
@@ -133,7 +141,7 @@ class GS1Message:
             ]
         )
         normalized_string = "".join(parts)
-        return GS1Message.parse(normalized_string)
+        return GS1Message.parse(normalized_string, rcn_region=rcn_region)
 
     def as_hri(self) -> str:
         """Render as a human readable interpretation (HRI).

--- a/src/biip/gs1/_messages.py
+++ b/src/biip/gs1/_messages.py
@@ -125,8 +125,7 @@ class GS1Message:
         for ai_number, ai_data in matches:
             if ai_number not in _GS1_APPLICATION_IDENTIFIERS:
                 raise ParseError(
-                    "Does not recognize the GS1 Application Identifier "
-                    f"{ai_number!r} in {value!r}."
+                    f"Unknown GS1 Application Identifier {ai_number!r} in {value!r}."
                 )
             pairs.append((_GS1_APPLICATION_IDENTIFIERS[ai_number], ai_data))
 

--- a/src/biip/gs1/_messages.py
+++ b/src/biip/gs1/_messages.py
@@ -7,7 +7,12 @@ from dataclasses import dataclass
 from typing import Iterable, List, Optional, Union
 
 from biip import ParseError
-from biip.gs1 import DEFAULT_SEPARATOR_CHARS, GS1ApplicationIdentifier, GS1ElementString
+from biip.gs1 import (
+    ASCII_GROUP_SEPARATOR,
+    DEFAULT_SEPARATOR_CHARS,
+    GS1ApplicationIdentifier,
+    GS1ElementString,
+)
 from biip.gs1._application_identifiers import _GS1_APPLICATION_IDENTIFIERS
 from biip.gtin import RcnRegion
 
@@ -111,7 +116,13 @@ class GS1Message:
             pairs.append((_GS1_APPLICATION_IDENTIFIERS[ai_number], ai_data))
 
         normalized_string = "".join(
-            "".join([gs1ai.ai, value, ("\x1d" if gs1ai.fnc1_required else "")])
+            "".join(
+                [
+                    gs1ai.ai,
+                    value,
+                    (ASCII_GROUP_SEPARATOR if gs1ai.fnc1_required else ""),
+                ]
+            )
             for gs1ai, value in pairs
         )
         return GS1Message.parse(normalized_string)

--- a/src/biip/gs1/_messages.py
+++ b/src/biip/gs1/_messages.py
@@ -99,6 +99,12 @@ class GS1Message:
         Raises:
             ParseError: If parsing of the data fails.
         """
+        value = value.strip()
+        if not value.startswith("("):
+            raise ParseError(
+                f"Expected HRI string {value!r} to start with a parenthesis."
+            )
+
         pattern = r"\((\d+)\)(\w+)"
         matches = re.findall(pattern, value)
         if not matches:

--- a/tests/gs1/test_messages.py
+++ b/tests/gs1/test_messages.py
@@ -359,7 +359,7 @@ def test_parse_hri_fails_if_ai_is_unknown(value: str) -> None:
         GS1Message.parse_hri(value)
 
     assert str(exc_info.value) == (
-        "Does not recognize the GS1 Application Identifier '1' in '(1)15210526'."
+        "Unknown GS1 Application Identifier '1' in '(1)15210526'."
     )
 
 

--- a/tests/gs1/test_messages.py
+++ b/tests/gs1/test_messages.py
@@ -1,4 +1,5 @@
 from datetime import date
+from decimal import Decimal
 from typing import Iterable, List
 
 import pytest
@@ -11,7 +12,7 @@ from biip.gs1 import (
     GS1Message,
     GS1Prefix,
 )
-from biip.gtin import Gtin, GtinFormat
+from biip.gtin import Gtin, GtinFormat, Rcn, RcnRegion
 
 
 @pytest.mark.parametrize(
@@ -293,6 +294,19 @@ def test_parse_strips_surrounding_whitespace() -> None:
 )
 def test_parse_hri(value: str, expected: GS1Message) -> None:
     assert GS1Message.parse_hri(value) == expected
+
+
+def test_parse_hri_with_gtin_with_variable_weight() -> None:
+    result = GS1Message.parse_hri(
+        "(01)02302148210869",
+        rcn_region=RcnRegion.NORWAY,
+    )
+
+    gs1_gtin = result.get(ai="01")
+    assert gs1_gtin
+    gtin = gs1_gtin.gtin
+    assert isinstance(gtin, Rcn)
+    assert gtin.weight == Decimal("1.086")
 
 
 def test_parse_hri_strips_surrounding_whitespace() -> None:

--- a/tests/gs1/test_messages.py
+++ b/tests/gs1/test_messages.py
@@ -173,7 +173,7 @@ def test_parse_fails_if_unparsed_data_left() -> None:
 
 def test_parse_fails_if_fixed_length_field_ends_with_separator_char() -> None:
     # 15... is a fixed length date.
-    # \1xd is the default separator character in an illegal position.
+    # \x1d is the default separator character in an illegal position.
     # 10... is any other field.
     value = "15210526\x1d100329"
 

--- a/tests/gs1/test_messages.py
+++ b/tests/gs1/test_messages.py
@@ -296,6 +296,39 @@ def test_parse_hri(value: str, expected: GS1Message) -> None:
 
 
 @pytest.mark.parametrize(
+    "value",
+    [
+        "",  # Empty string
+        "aa15210526",  # Invalid data
+        "15210526100329",  # Valid data, without parenthesis
+    ],
+)
+def test_parse_hri_fails_if_no_pattern_matches(value: str) -> None:
+    with pytest.raises(ParseError) as exc_info:
+        GS1Message.parse_hri(value)
+
+    assert str(exc_info.value) == (
+        "Could not find any GS1 Application Identifiers in "
+        f"{value!r}. Expected format: '(AI)DATA(AI)DATA'."
+    )
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "(1)15210526",  # Unknown AI
+    ],
+)
+def test_parse_hri_fails_if_ai_is_unknown(value: str) -> None:
+    with pytest.raises(ParseError) as exc_info:
+        GS1Message.parse_hri(value)
+
+    assert str(exc_info.value) == (
+        "Does not recognize the GS1 Application Identifier '1' in '(1)15210526'."
+    )
+
+
+@pytest.mark.parametrize(
     "value, expected",
     [
         (


### PR DESCRIPTION
This builds upon #155 to add more error handling and support for GTINs with
variable weight (RCNs) within the HRI strings.

Review commit-by-commit recommended.
