### PR TITLE
Don't fail GS1 message parsing on inner format error

### DIFF
--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -15,8 +15,9 @@ example, the value can be interpreted as either a GTIN or a GS1 Message.
     element_strings=[GS1ElementString(ai=GS1ApplicationIdentifier(ai='96',
     description='Company internal information', data_title='INTERNAL',
     fnc1_required=True, format='N2+X..90'), value='385074',
-    pattern_groups=['385074'], gln=None, gtin=None, sscc=None, date=None,
-    decimal=None, money=None)])
+    pattern_groups=['385074'], gln=None, gln_error=None, gtin=None,
+    gtin_error=None, sscc=None, sscc_error=None, date=None, decimal=None,
+    money=None)])
 
 In the next example, the value is only valid as a GS1 Message and the GTIN
 parser returns an error explaining why the value cannot be interpreted as a
@@ -33,8 +34,9 @@ the check digits are incorrect.
     element_strings=[GS1ElementString(ai=GS1ApplicationIdentifier(ai='15',
     description='Best before date (YYMMDD)', data_title='BEST BEFORE or BEST
     BY', fnc1_required=False, format='N2+N6'), value='210527',
-    pattern_groups=['210527'], gln=None, gtin=None, sscc=None,
-    date=datetime.date(2021, 5, 27), decimal=None, money=None)])
+    pattern_groups=['210527'], gln=None, gln_error=None, gtin=None,
+    gtin_error=None, sscc=None, sscc_error=None, date=datetime.date(2021, 5,
+    27), decimal=None, money=None)])
 
 If a value cannot be interpreted as any supported format, an exception is
 raised with a reason from each parser.

--- a/src/biip/gs1/__init__.py
+++ b/src/biip/gs1/__init__.py
@@ -43,11 +43,11 @@ In this example, the first element string is a GTIN.
     >>> msg.element_strings[0]
     GS1ElementString(ai=GS1ApplicationIdentifier(ai='01', description='Global
     Trade Item Number (GTIN)', data_title='GTIN', fnc1_required=False,
-    format='N2+N14'), value='07032069804988',
-    pattern_groups=['07032069804988'], gln=None,
-    gtin=Gtin(value='07032069804988', format=GtinFormat.GTIN_13,
-    prefix=GS1Prefix(value='703', usage='GS1 Norway'), payload='703206980498',
-    check_digit=8, packaging_level=None), sscc=None, date=None, decimal=None,
+    format='N2+N14'), value='07032069804988', pattern_groups=['07032069804988'],
+    gln=None, gln_error=None, gtin=Gtin(value='07032069804988',
+    format=GtinFormat.GTIN_13, prefix=GS1Prefix(value='703', usage='GS1
+    Norway'), payload='703206980498', check_digit=8, packaging_level=None),
+    gtin_error=None, sscc=None, sscc_error=None, date=None, decimal=None,
     money=None)
 
 The message object has :meth:`~GS1Message.get` and :meth:`~GS1Message.filter`
@@ -58,13 +58,15 @@ methods to lookup element strings either by the Application Identifier's
     GS1ElementString(ai=GS1ApplicationIdentifier(ai='15', description='Best
     before date (YYMMDD)', data_title='BEST BEFORE or BEST BY',
     fnc1_required=False, format='N2+N6'), value='210526',
-    pattern_groups=['210526'], gln=None, gtin=None, sscc=None,
-    date=datetime.date(2021, 5, 26), decimal=None, money=None)
+    pattern_groups=['210526'], gln=None, gln_error=None, gtin=None,
+    gtin_error=None, sscc=None, sscc_error=None, date=datetime.date(2021, 5,
+    26), decimal=None, money=None)
     >>> msg.get(ai="10")
     GS1ElementString(ai=GS1ApplicationIdentifier(ai='10', description='Batch
     or lot number', data_title='BATCH/LOT', fnc1_required=True,
     format='N2+X..20'), value='0329', pattern_groups=['0329'], gln=None,
-    gtin=None, sscc=None, date=None, decimal=None, money=None)
+    gln_error=None, gtin=None, gtin_error=None, sscc=None, sscc_error=None,
+    date=None, decimal=None, money=None)
 """
 
 from typing import Tuple

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -94,6 +94,17 @@ class GS1ElementString:
     ) -> GS1ElementString:
         """Extract the first GS1 Element String from the given value.
 
+        If the element string contains a primitive data type, like a date,
+        decimal number, or currency, it will be parsed and stored in the
+        ``date``, ``decimal``, or ``money`` field respectively. If parsing of
+        a primitive data type fails, a ``ParseError`` will be raised.
+
+        If the element string contains another supported format, like a GLN,
+        GTIN, or SSCC, it will parsed and validated, and the result stored in
+        the fields ``gln``, ``gtin``, or ``sscc`` respectively. If parsing or
+        validation of an inner format fails, the ``gln_error``, ``gtin_error``,
+        or ``sscc_error`` field will be set. No ``ParseError`` will be raised.
+
         Args:
             value: The string to extract an Element String from. May contain
                 more than one Element String.

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -145,19 +145,34 @@ class GS1ElementString:
         if self.ai.ai[:2] != "41":
             return
 
-        self.gln = Gln.parse(self.value)
+        try:
+            self.gln = Gln.parse(self.value)
+            self.gln_error = None
+        except ParseError as exc:
+            self.gln = None
+            self.gln_error = str(exc)
 
     def _set_gtin(self, *, rcn_region: Optional[RcnRegion] = None) -> None:
         if self.ai.ai not in ("01", "02"):
             return
 
-        self.gtin = Gtin.parse(self.value, rcn_region=rcn_region)
+        try:
+            self.gtin = Gtin.parse(self.value, rcn_region=rcn_region)
+            self.gtin_error = None
+        except ParseError as exc:
+            self.gtin = None
+            self.gtin_error = str(exc)
 
     def _set_sscc(self) -> None:
         if self.ai.ai != "00":
             return
 
-        self.sscc = Sscc.parse(self.value)
+        try:
+            self.sscc = Sscc.parse(self.value)
+            self.sscc_error = None
+        except ParseError as exc:
+            self.sscc = None
+            self.sscc_error = str(exc)
 
     def _set_date(self) -> None:
         if self.ai.ai not in ("11", "12", "13", "15", "16", "17"):

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -37,11 +37,12 @@ class GS1ElementString:
         GS1ElementString(ai=GS1ApplicationIdentifier(ai='01',
         description='Global Trade Item Number (GTIN)', data_title='GTIN',
         fnc1_required=False, format='N2+N14'), value='07032069804988',
-        pattern_groups=['07032069804988'], gln=None,
+        pattern_groups=['07032069804988'], gln=None, gln_error=None,
         gtin=Gtin(value='07032069804988', format=GtinFormat.GTIN_13,
         prefix=GS1Prefix(value='703', usage='GS1 Norway'),
-        payload='703206980498', check_digit=8, packaging_level=None), sscc=None,
-        date=None, decimal=None, money=None)
+        payload='703206980498', check_digit=8, packaging_level=None),
+        gtin_error=None, sscc=None, sscc_error=None, date=None, decimal=None,
+        money=None)
         >>> element_string.as_hri()
         '(01)07032069804988'
     """
@@ -58,11 +59,20 @@ class GS1ElementString:
     #: A GLN created from the element string, if the AI represents a GLN.
     gln: Optional[Gln] = None
 
+    #: The GLN parse error, if parsing as a GLN was attempted and failed.
+    gln_error: Optional[str] = None
+
     #: A GTIN created from the element string, if the AI represents a GTIN.
     gtin: Optional[Gtin] = None
 
+    #: The GTIN parse error, if parsing as a GTIN was attempted and failed.
+    gtin_error: Optional[str] = None
+
     #: An SSCC created from the element string, if the AI represents a SSCC.
     sscc: Optional[Sscc] = None
+
+    #: The SSCC parse error, if parsing as an SSCC was attempted and failed.
+    sscc_error: Optional[str] = None
 
     #: A date created from the element string, if the AI represents a date.
     date: Optional[datetime.date] = None

--- a/tests/gs1/test_element_strings.py
+++ b/tests/gs1/test_element_strings.py
@@ -80,6 +80,53 @@ def test_extract(value: str, expected: GS1ElementString) -> None:
 
 
 @pytest.mark.parametrize(
+    "value, expected",
+    [
+        (  # GS1 element string with invalid GLN
+            "4101234567890127",
+            GS1ElementString(
+                ai=GS1ApplicationIdentifier.extract("410"),
+                value="1234567890127",
+                pattern_groups=["1234567890127"],
+                gln=None,  # Not set, because GLN is invalid.
+                gln_error=(
+                    "Invalid GLN check digit for '1234567890127': " "Expected 8, got 7."
+                ),
+            ),
+        ),
+        (  # GS1 element string with invalid GTIN
+            "0107032069804987",
+            GS1ElementString(
+                ai=GS1ApplicationIdentifier.extract("01"),
+                value="07032069804987",
+                pattern_groups=["07032069804987"],
+                gtin=None,  # Not set, because GTIN is invalid.
+                gtin_error=(
+                    "Invalid GTIN check digit for '07032069804987': "
+                    "Expected 8, got 7."
+                ),
+            ),
+        ),
+        (  # GS1 element string with invalid SSCC
+            "00376130321109103421",
+            GS1ElementString(
+                ai=GS1ApplicationIdentifier.extract("00"),
+                value="376130321109103421",
+                pattern_groups=["376130321109103421"],
+                sscc=None,  # Not set, because SSCC is invalid.
+                sscc_error=(
+                    "Invalid SSCC check digit for '376130321109103421': "
+                    "Expected 0, got 1."
+                ),
+            ),
+        ),
+    ],
+)
+def test_extract_with_nested_error(value: str, expected: GS1ElementString) -> None:
+    assert GS1ElementString.extract(value) == expected
+
+
+@pytest.mark.parametrize(
     "ai_code, bad_value",
     [
         # Too short product number


### PR DESCRIPTION
This is a breaking change, as we no longer raise a `ParseError` when inner
formats (like GLN, GTIN, and SSCC) inside a GS1 element string fails parsing or
validation. Instead we set the associated error fields on the returned
`GS1ElementString`, e.g. `gln_error`, `gtin_error`, or `sscc_error`.

The reason for this change is that there might be use cases where you're
interested in the other parts of the GS1 message than the one that fails
validation.

Fixes #157
