### PR TITLE
Forward inner parse error in `GS1Message` to `ParseResult`

### DIFF
--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -235,10 +235,10 @@ def _parse_gs1_message(
     else:
         # If the GS1 Message contains an SSCC, set SSCC on the top-level result.
         ai_00 = result.gs1_message.get(ai="00")
-        if ai_00 is not None and ai_00.sscc is not None:
-            queue.append((_parse_sscc, ai_00.sscc.value))
+        if ai_00 is not None:
+            queue.append((_parse_sscc, ai_00.value))
 
         # If the GS1 Message contains an GTIN, set GTIN on the top-level result.
         ai_01 = result.gs1_message.get(ai="01")
-        if ai_01 is not None and ai_01.gtin is not None:
-            queue.append((_parse_gtin, ai_01.gtin.value))
+        if ai_01 is not None:
+            queue.append((_parse_gtin, ai_01.value))

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -354,6 +354,39 @@ from biip.upc import Upc, UpcFormat
             ),
         ),
         (
+            # GS1 AI: Invalid SSCC
+            "00376130321109103421",
+            ParseResult(
+                value="00376130321109103421",
+                gtin_error=(
+                    "Failed to parse '00376130321109103421' as GTIN: "
+                    "Expected 8, 12, 13, or 14 digits, got 20."
+                ),
+                upc_error=(
+                    "Failed to parse '00376130321109103421' as UPC: "
+                    "Expected 6, 7, 8, or 12 digits, got 20."
+                ),
+                sscc_error=(
+                    "Invalid SSCC check digit for "
+                    "'376130321109103421': Expected 0, got 1."
+                ),
+                gs1_message=GS1Message(
+                    value="00376130321109103421",
+                    element_strings=[
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("00"),
+                            value="376130321109103421",
+                            pattern_groups=["376130321109103421"],
+                            sscc_error=(
+                                "Invalid SSCC check digit for "
+                                "'376130321109103421': Expected 0, got 1."
+                            ),
+                        ),
+                    ],
+                ),
+            ),
+        ),
+        (
             # GS1 AI: GTIN-12. GTIN-12 is also valid as UPC-A.
             "0100123601057072",
             ParseResult(
@@ -430,6 +463,39 @@ from biip.upc import Upc, UpcFormat
                                 prefix=GS1Prefix(value="590", usage="GS1 Poland"),
                                 payload="590123412345",
                                 check_digit=7,
+                            ),
+                        )
+                    ],
+                ),
+            ),
+        ),
+        (
+            # GS1 AI: Invalid GTIN
+            "0105901234123458",
+            ParseResult(
+                value="0105901234123458",
+                gtin_error=(
+                    "Invalid GTIN check digit for '05901234123458': "
+                    "Expected 7, got 8."
+                ),
+                upc_error=(
+                    "Failed to parse '0105901234123458' as UPC: "
+                    "Expected 6, 7, 8, or 12 digits, got 16."
+                ),
+                sscc_error=(
+                    "Failed to parse '0105901234123458' as SSCC: "
+                    "Expected 18 digits, got 16."
+                ),
+                gs1_message=GS1Message(
+                    value="0105901234123458",
+                    element_strings=[
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("01"),
+                            value="05901234123458",
+                            pattern_groups=["05901234123458"],
+                            gtin_error=(
+                                "Invalid GTIN check digit for '05901234123458': "
+                                "Expected 7, got 8."
                             ),
                         )
                     ],


### PR DESCRIPTION
Related to #157 and builds upon #169
