### PR TITLE
Add rcn_verify_variable_measure configuration flag

### DIFF
--- a/src/biip/gs1/_messages.py
+++ b/src/biip/gs1/_messages.py
@@ -40,6 +40,7 @@ class GS1Message:
         value: str,
         *,
         rcn_region: Optional[RcnRegion] = None,
+        rcn_verify_variable_measure: bool = True,
         separator_chars: Iterable[str] = DEFAULT_SEPARATOR_CHARS,
     ) -> GS1Message:
         """Parse a string from a barcode scan as a GS1 message with AIs.
@@ -49,6 +50,10 @@ class GS1Message:
             rcn_region: The geographical region whose rules should be used to
                 interpret Restricted Circulation Numbers (RCN).
                 Needed to extract e.g. variable weight/price from GTIN.
+            rcn_verify_variable_measure: Whether to verify that the variable
+                measure in a RCN matches its check digit, if present. Some
+                companies use the variable measure check digit for other
+                purposes, requiring this check to be disabled.
             separator_chars: Characters used in place of the FNC1 symbol.
                 Defaults to `<GS>` (ASCII value 29).
                 If variable-length fields in the middle of the message are
@@ -67,7 +72,10 @@ class GS1Message:
 
         while rest:
             element_string = GS1ElementString.extract(
-                rest, rcn_region=rcn_region, separator_chars=separator_chars
+                rest,
+                rcn_region=rcn_region,
+                rcn_verify_variable_measure=rcn_verify_variable_measure,
+                separator_chars=separator_chars,
             )
             element_strings.append(element_string)
 
@@ -92,6 +100,7 @@ class GS1Message:
         value: str,
         *,
         rcn_region: Optional[RcnRegion] = None,
+        rcn_verify_variable_measure: bool = True,
     ) -> GS1Message:
         """Parse the GS1 string given in HRI (human readable interpretation) format.
 
@@ -100,6 +109,10 @@ class GS1Message:
             rcn_region: The geographical region whose rules should be used to
                 interpret Restricted Circulation Numbers (RCN).
                 Needed to extract e.g. variable weight/price from GTIN.
+            rcn_verify_variable_measure: Whether to verify that the variable
+                measure in a RCN matches its check digit, if present. Some
+                companies use the variable measure check digit for other
+                purposes, requiring this check to be disabled.
 
         Returns:
             A message object with one or more element strings.
@@ -140,7 +153,11 @@ class GS1Message:
             ]
         )
         normalized_string = "".join(parts)
-        return GS1Message.parse(normalized_string, rcn_region=rcn_region)
+        return GS1Message.parse(
+            normalized_string,
+            rcn_region=rcn_region,
+            rcn_verify_variable_measure=rcn_verify_variable_measure,
+        )
 
     def as_hri(self) -> str:
         """Render as a human readable interpretation (HRI).

--- a/src/biip/gtin/_gtin.py
+++ b/src/biip/gtin/_gtin.py
@@ -44,7 +44,13 @@ class Gtin:
     packaging_level: Optional[int] = None
 
     @classmethod
-    def parse(cls, value: str, *, rcn_region: Optional[RcnRegion] = None) -> Gtin:
+    def parse(
+        cls,
+        value: str,
+        *,
+        rcn_region: Optional[RcnRegion] = None,
+        rcn_verify_variable_measure: bool = True,
+    ) -> Gtin:
         """Parse the given value into a :class:`Gtin` object.
 
         Both GTIN-8, GTIN-12, GTIN-13, and GTIN-14 are supported.
@@ -54,6 +60,10 @@ class Gtin:
             rcn_region: The geographical region whose rules should be used to
                 interpret Restricted Circulation Numbers (RCN).
                 Needed to extract e.g. variable weight/price from GTIN.
+            rcn_verify_variable_measure: Whether to verify that the variable
+                measure in a RCN matches its check digit, if present. Some
+                companies use the variable measure check digit for other
+                purposes, requiring this check to be disabled.
 
         Returns:
             GTIN data structure with the successfully extracted data.
@@ -126,7 +136,10 @@ class Gtin:
         )
 
         if isinstance(gtin, Rcn) and rcn_region is not None:
-            gtin._parse_with_regional_rules(rcn_region)
+            gtin._parse_with_regional_rules(
+                region=rcn_region,
+                verify_variable_measure=rcn_verify_variable_measure,
+            )
 
         return gtin
 


### PR DESCRIPTION
Some German suppliers are known to use the variable measure check digit in the
middle of the RCN as an additional product identifier digit. To support
products with RCNs constructed in this way, it is necessary to be able to
disable variable measure check digit verification.

This PR adds a parameter `rcn_verify_variable_measure` to all parse
functions/methods that can deal with RCNs:

- `biip.parse()`
- `biip.gtin.Gtin.parse()`
- `biip.gs1.GS1Message.parse{,_hri}()`

The default value of `rcn_verify_variable_measure` is `True`, to preserve
existing behavior. This addition is thus backwards compatible for existing
users of Biip.
