### PR TITLE
Tooling updates: Ruff and Poetry dependency groups

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ build:
     post_install:
       - pip install poetry
       - poetry config virtualenvs.create false
-      - poetry install --with docs --without dev
+      - poetry install --all-extras --only=main,docs
 
 sphinx:
   configuration: docs/conf.py

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -2,7 +2,7 @@
 
 project = "biip"
 author = "Stein Magnus Jodal"
-copyright = f"2020-2022, {author}"
+copyright = f"2020-2022, {author}"  # noqa: A001
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,25 +23,19 @@ def black(session):
 
 
 @nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+def ruff(session):
+    """Lint using ruff."""
+    args = session.posargs or locations
+    session.run("poetry", "install", "--no-root", "--only=ruff", external=True)
+    session.run("ruff", *args)
+
+
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
 def darglint(session):
     """Check docstrings using darglint."""
     args = session.posargs or ["src"]
     session.run("poetry", "install", "--no-root", "--only=darglint", external=True)
     session.run("darglint", *args)
-
-
-@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
-def flake8(session):
-    """Lint using flake8."""
-    args = session.posargs or locations
-    session.install(
-        "flake8",
-        "flake8-annotations",
-        "flake8-bugbear",
-        "flake8-docstrings",
-        "flake8-isort",
-    )
-    session.run("flake8", *args)
 
 
 @nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])

--- a/noxfile.py
+++ b/noxfile.py
@@ -14,6 +14,14 @@ def tests(session):
     session.run("pytest", *args)
 
 
+@nox.session(python="3.11")
+def coverage(session):
+    """Upload test coverage data."""
+    session.run("poetry", "install", "--no-root", "--only=tests", external=True)
+    session.run("coverage", "xml", "--fail-under=0")
+    session.run("codecov", *session.posargs)
+
+
 @nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
 def black(session):
     """Check formatting using Black."""
@@ -51,11 +59,3 @@ def docs(session):
     """Build the documentation."""
     session.run("poetry", "install", "--all-extras", "--only=main,docs", external=True)
     session.run("sphinx-build", "docs", "docs/_build")
-
-
-@nox.session(python="3.11")
-def coverage(session):
-    """Upload test coverage data."""
-    session.install("coverage[toml]", "codecov")
-    session.run("coverage", "xml", "--fail-under=0")
-    session.run("codecov", *session.posargs)

--- a/noxfile.py
+++ b/noxfile.py
@@ -10,7 +10,7 @@ locations = ["src", "tests", "noxfile.py", "docs/conf.py"]
 def tests(session):
     """Run the test suite."""
     args = session.posargs or ["--cov"]
-    session.run("poetry", "install", external=True)
+    session.run("poetry", "install", "--all-extras", "--only=main,tests", external=True)
     session.run("pytest", *args)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -41,10 +41,7 @@ def flake8(session):
 def mypy(session):
     """Type-check using mypy."""
     args = session.posargs or locations
-    session.install(
-        "mypy",
-        "types-dataclasses",
-    )
+    session.run("poetry", "install", "--only=mypy", external=True)
     session.run("mypy", *args)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -15,6 +15,14 @@ def tests(session):
 
 
 @nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+def black(session):
+    """Check formatting using Black."""
+    args = session.posargs or locations
+    session.run("poetry", "install", "--no-root", "--only=black", external=True)
+    session.run("black", *args)
+
+
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
 def flake8(session):
     """Lint using flake8."""
     args = session.posargs or locations
@@ -22,7 +30,6 @@ def flake8(session):
         "darglint",
         "flake8",
         "flake8-annotations",
-        "flake8-black",
         "flake8-bugbear",
         "flake8-docstrings",
         "flake8-isort",

--- a/noxfile.py
+++ b/noxfile.py
@@ -23,11 +23,18 @@ def black(session):
 
 
 @nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
+def darglint(session):
+    """Check docstrings using darglint."""
+    args = session.posargs or ["src"]
+    session.run("poetry", "install", "--no-root", "--only=darglint", external=True)
+    session.run("darglint", *args)
+
+
+@nox.session(python=["3.7", "3.8", "3.9", "3.10", "3.11"])
 def flake8(session):
     """Lint using flake8."""
     args = session.posargs or locations
     session.install(
-        "darglint",
         "flake8",
         "flake8-annotations",
         "flake8-bugbear",

--- a/noxfile.py
+++ b/noxfile.py
@@ -44,18 +44,7 @@ def mypy(session):
 @nox.session(python="3.11")
 def docs(session):
     """Build the documentation."""
-    session.run(
-        "poetry",
-        "install",
-        "--no-dev",
-        "--extras=money",
-        external=True,
-    )
-    session.install(
-        "sphinx",
-        "sphinx-rtd-theme",
-        "sphinx-autodoc-typehints",
-    )
+    session.run("poetry", "install", "--all-extras", "--only=main,docs", external=True)
     session.run("sphinx-build", "docs", "docs/_build")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ select = [
     "D",   # pydocstyle
     "E",   # pycodestyle
     "F",   # pyflakes
+    "FBT", # flake8-boolean-trap
     "I",   # isort
     "N",   # pep8-naming
     "Q",   # flake8-quotes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,14 +23,6 @@ py-moneyed = { version = ">=0.8", optional = true }
 [tool.poetry.extras]
 money = ["py-moneyed"]
 
-[tool.poetry.group.dev.dependencies]
-flake8 = "^5.0.4"
-flake8-annotations = "^2.9.1"
-flake8-bugbear = "^23.2.13"
-flake8-docstrings = "^1.7.0"
-flake8-isort = "^6.0.0"
-isort = "^5.11.5"
-
 [tool.poetry.group.black.dependencies]
 black = "^23.1.0"
 
@@ -44,6 +36,9 @@ sphinx-autodoc-typehints = "^1.12.0"
 
 [tool.poetry.group.mypy.dependencies]
 mypy = "^1.1.1"
+
+[tool.poetry.group.ruff.dependencies]
+ruff = "^0.0.254"
 
 [tool.poetry.group.scripts.dependencies]
 beautifulsoup4 = "^4.11.2"
@@ -70,9 +65,6 @@ source = ["biip"]
 fail_under = 100
 show_missing = true
 
-[tool.isort]
-profile = "black"
-
 [tool.pytest.ini_options]
 minversion = "6.0"
 addopts = "--xdoc"
@@ -91,6 +83,33 @@ disallow_untyped_defs = true
 [[tool.mypy.overrides]]
 module = ["bs4.*", "moneyed.*", "nox.*", "pytest.*"]
 ignore_missing_imports = true
+
+[tool.ruff]
+select = [
+    "ANN", # flake8-annotations
+    "B",   # flake8-bugbear
+    "C",   # flake8-comprehensions
+    "D",   # pydocstyle
+    "E",   # pycodestyle
+    "F",   # pyflakes
+    "I",   # isort
+    "W",   # pycodestyle
+]
+ignore = [
+    "ANN101", # missing-type-self
+    "ANN102", # missing-type-cls
+]
+target-version = "py37"
+
+[tool.ruff.per-file-ignores]
+"noxfile.py" = ["ANN"]
+"tests/*" = ["D"]
+
+[tool.ruff.isort]
+known-first-party = ["biip"]
+
+[tool.ruff.pydocstyle]
+convention = "google"
 
 [build-system]
 requires = ["poetry-core>=1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,11 +96,12 @@ select = [
     "E",   # pycodestyle
     "F",   # pyflakes
     "I",   # isort
-    "SIM", # flake8-simplify
+    "Q",   # flake8-quotes
     "RUF", # ruff
+    "SIM", # flake8-simplify
+    "T20", # flake8-print
     "TCH", # flake8-type-checking
     "TID", # flake8-tidy-imports
-    "Q",   # flake8-quotes
     "W",   # pycodestyle
 ]
 ignore = [
@@ -111,6 +112,7 @@ target-version = "py37"
 
 [tool.ruff.per-file-ignores]
 "noxfile.py" = ["ANN"]
+"scripts/*" = ["T20"]
 "tests/*" = ["D"]
 
 [tool.ruff.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,6 +103,7 @@ select = [
     "INP", # flake8-no-pep420
     "ISC", # flake8-implicit-str-concat
     "N",   # pep8-naming
+    "PIE", # flake8-pie
     "Q",   # flake8-quotes
     "RUF", # ruff
     "SIM", # flake8-simplify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ select = [
     "E",   # pycodestyle
     "F",   # pyflakes
     "I",   # isort
+    "N",   # pep8-naming
     "Q",   # flake8-quotes
     "RUF", # ruff
     "SIM", # flake8-simplify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ select = [
     "INP", # flake8-no-pep420
     "ISC", # flake8-implicit-str-concat
     "N",   # pep8-naming
+    "PGH", # pygrep-hooks
     "PIE", # flake8-pie
     "PT",  # flake8-pytest-style
     "PTH", # flake8-use-pathlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,9 @@ black = "^23.1.0"
 [tool.poetry.group.darglint.dependencies]
 darglint = "^1.8.1"
 
+[tool.poetry.group.dev.dependencies]
+nox = "^2022.11.21"
+
 [tool.poetry.group.docs.dependencies]
 sphinx = "^4.0.0"
 sphinx-rtd-theme = "^1.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ select = [
     "N",   # pep8-naming
     "PIE", # flake8-pie
     "PT",  # flake8-pytest-style
+    "PTH", # flake8-use-pathlib
     "Q",   # flake8-quotes
     "RET", # flake8-return
     "RSE", # flake8-raise

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ select = [
     "PIE", # flake8-pie
     "PT",  # flake8-pytest-style
     "Q",   # flake8-quotes
+    "RSE", # flake8-raise
     "RUF", # ruff
     "SIM", # flake8-simplify
     "T20", # flake8-print

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,6 +107,10 @@ select = [
     "N",   # pep8-naming
     "PGH", # pygrep-hooks
     "PIE", # flake8-pie
+    "PLC", # pylint convention
+    "PLE", # pylint error
+    "PLR", # pylint refactor
+    "PLW", # pylint warning
     "PT",  # flake8-pytest-style
     "PTH", # flake8-use-pathlib
     "Q",   # flake8-quotes
@@ -122,10 +126,11 @@ select = [
     "W",   # pycodestyle
 ]
 ignore = [
-    "A003",   # builtin-attribute-shadowing
-    "ANN101", # missing-type-self
-    "ANN102", # missing-type-cls
-    "RET504", # unnecessary-assign
+    "A003",    # builtin-attribute-shadowing
+    "ANN101",  # missing-type-self
+    "ANN102",  # missing-type-cls
+    "PLR2004", # magic-value-comparison
+    "RET504",  # unnecessary-assign
     #
     # Equivalent to `pyupgrade --keep-runtime-typing`:
     "UP006", # deprecated-collection-type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ flake8-docstrings = "^1.7.0"
 flake8-isort = "^6.0.0"
 httpx = "^0.23.3"
 isort = "^5.11.5"
-mypy = "^1.1.1"
 
 [tool.poetry.group.black.dependencies]
 black = "^23.1.0"
@@ -42,6 +41,9 @@ black = "^23.1.0"
 sphinx = "^4.0.0"
 sphinx-rtd-theme = "^1.1.1"
 sphinx-autodoc-typehints = "^1.12.0"
+
+[tool.poetry.group.mypy.dependencies]
+mypy = "^1.1.1"
 
 [tool.poetry.group.tests.dependencies]
 codecov = "^2.1.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,14 +24,12 @@ py-moneyed = { version = ">=0.8", optional = true }
 money = ["py-moneyed"]
 
 [tool.poetry.group.dev.dependencies]
-beautifulsoup4 = "^4.11.2"
 darglint = "^1.8.1"
 flake8 = "^5.0.4"
 flake8-annotations = "^2.9.1"
 flake8-bugbear = "^23.2.13"
 flake8-docstrings = "^1.7.0"
 flake8-isort = "^6.0.0"
-httpx = "^0.23.3"
 isort = "^5.11.5"
 
 [tool.poetry.group.black.dependencies]
@@ -44,6 +42,10 @@ sphinx-autodoc-typehints = "^1.12.0"
 
 [tool.poetry.group.mypy.dependencies]
 mypy = "^1.1.1"
+
+[tool.poetry.group.scripts.dependencies]
+beautifulsoup4 = "^4.11.2"
+httpx = "^0.23.3"
 
 [tool.poetry.group.tests.dependencies]
 codecov = "^2.1.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,8 +25,6 @@ money = ["py-moneyed"]
 
 [tool.poetry.group.dev.dependencies]
 beautifulsoup4 = "^4.11.2"
-codecov = "^2.1.12"
-coverage = "^7.2.1"
 darglint = "^1.8.1"
 flake8 = "^5.0.4"
 flake8-annotations = "^2.9.1"
@@ -36,10 +34,6 @@ flake8-isort = "^6.0.0"
 httpx = "^0.23.3"
 isort = "^5.11.5"
 mypy = "^1.1.1"
-py-moneyed = "^3.0"
-pytest = "^7.2.2"
-pytest-cov = "^4.0.0"
-xdoctest = "^1.1.1"
 
 [tool.poetry.group.black.dependencies]
 black = "^23.1.0"
@@ -48,6 +42,13 @@ black = "^23.1.0"
 sphinx = "^4.0.0"
 sphinx-rtd-theme = "^1.1.1"
 sphinx-autodoc-typehints = "^1.12.0"
+
+[tool.poetry.group.tests.dependencies]
+codecov = "^2.1.12"
+coverage = "^7.2.1"
+pytest = "^7.2.2"
+pytest-cov = "^4.0.0"
+xdoctest = "^1.1.1"
 
 [tool.black]
 target-version = ["py37", "py38", "py39", "py310", "py311"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,6 +89,7 @@ ignore_missing_imports = true
 
 [tool.ruff]
 select = [
+    "A",   # flake8-builtins
     "ANN", # flake8-annotations
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
@@ -109,6 +110,7 @@ select = [
     "W",   # pycodestyle
 ]
 ignore = [
+    "A003",   # builtin-attribute-shadowing
     "ANN101", # missing-type-self
     "ANN102", # missing-type-cls
     #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ select = [
     "ISC", # flake8-implicit-str-concat
     "N",   # pep8-naming
     "PIE", # flake8-pie
+    "PT",  # flake8-pytest-style
     "Q",   # flake8-quotes
     "RUF", # ruff
     "SIM", # flake8-simplify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,8 @@ ignore_missing_imports = true
 select = [
     "ANN", # flake8-annotations
     "B",   # flake8-bugbear
-    "C",   # flake8-comprehensions
+    "C4",  # flake8-comprehensions
+    "C90", # mccabe
     "D",   # pydocstyle
     "E",   # pycodestyle
     "F",   # pyflakes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ select = [
     "F",   # pyflakes
     "FBT", # flake8-boolean-trap
     "I",   # isort
+    "ISC", # flake8-implicit-str-concat
     "N",   # pep8-naming
     "Q",   # flake8-quotes
     "RUF", # ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ select = [
     "T20", # flake8-print
     "TCH", # flake8-type-checking
     "TID", # flake8-tidy-imports
+    "TRY", # tryceratops
     "UP",  # pyupgrade
     "W",   # pycodestyle
 ]
@@ -131,6 +132,7 @@ ignore = [
     "ANN102",  # missing-type-cls
     "PLR2004", # magic-value-comparison
     "RET504",  # unnecessary-assign
+    "TRY003",  # raise-vanilla-args
     #
     # Equivalent to `pyupgrade --keep-runtime-typing`:
     "UP006", # deprecated-collection-type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ select = [
     "RSE", # flake8-raise
     "RUF", # ruff
     "SIM", # flake8-simplify
+    "SLF", # flake8-self
     "T20", # flake8-print
     "TCH", # flake8-type-checking
     "TID", # flake8-tidy-imports

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,6 +106,7 @@ select = [
     "PIE", # flake8-pie
     "PT",  # flake8-pytest-style
     "Q",   # flake8-quotes
+    "RET", # flake8-return
     "RSE", # flake8-raise
     "RUF", # ruff
     "SIM", # flake8-simplify
@@ -119,6 +120,7 @@ ignore = [
     "A003",   # builtin-attribute-shadowing
     "ANN101", # missing-type-self
     "ANN102", # missing-type-cls
+    "RET504", # unnecessary-assign
     #
     # Equivalent to `pyupgrade --keep-runtime-typing`:
     "UP006", # deprecated-collection-type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ select = [
     "C4",  # flake8-comprehensions
     "C90", # mccabe
     "D",   # pydocstyle
+    "DTZ", # flake8-datetimez
     "E",   # pycodestyle
     "F",   # pyflakes
     "FBT", # flake8-boolean-trap

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,7 @@ select = [
     "F",   # pyflakes
     "FBT", # flake8-boolean-trap
     "I",   # isort
+    "INP", # flake8-no-pep420
     "ISC", # flake8-implicit-str-concat
     "N",   # pep8-naming
     "Q",   # flake8-quotes
@@ -123,8 +124,9 @@ ignore = [
 target-version = "py37"
 
 [tool.ruff.per-file-ignores]
+"docs/*" = ["INP001"]
 "noxfile.py" = ["ANN"]
-"scripts/*" = ["T20"]
+"scripts/*" = ["INP001", "T20"]
 "tests/*" = ["D"]
 
 [tool.ruff.isort]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ select = [
     "D",   # pydocstyle
     "DTZ", # flake8-datetimez
     "E",   # pycodestyle
+    "ERA", # eradicate
     "F",   # pyflakes
     "FBT", # flake8-boolean-trap
     "I",   # isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,11 +104,16 @@ select = [
     "T20", # flake8-print
     "TCH", # flake8-type-checking
     "TID", # flake8-tidy-imports
+    "UP",  # pyupgrade
     "W",   # pycodestyle
 ]
 ignore = [
     "ANN101", # missing-type-self
     "ANN102", # missing-type-cls
+    #
+    # Equivalent to `pyupgrade --keep-runtime-typing`:
+    "UP006", # deprecated-collection-type
+    "UP007", # typing-union
 ]
 target-version = "py37"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,6 @@ xdoctest = "^1.1.1"
 sphinx = "^4.0.0"
 sphinx-rtd-theme = "^1.1.1"
 sphinx-autodoc-typehints = "^1.12.0"
-py-moneyed = "^3.0"
 
 [tool.black]
 target-version = ["py37", "py38", "py39", "py310", "py311"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ ignore_missing_imports = true
 select = [
     "A",   # flake8-builtins
     "ANN", # flake8-annotations
+    "ARG", # flake8-unused-arguments
     "B",   # flake8-bugbear
     "C4",  # flake8-comprehensions
     "C90", # mccabe

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,7 @@ select = [
     "F",   # pyflakes
     "I",   # isort
     "RUF", # ruff
+    "Q",   # flake8-quotes
     "W",   # pycodestyle
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ httpx = "^0.23.3"
 
 [tool.poetry.group.tests.dependencies]
 codecov = "^2.1.12"
-coverage = "^7.2.1"
+coverage = { extras = ["toml"], version = "^7.2.1" }
 pytest = "^7.2.2"
 pytest-cov = "^4.0.0"
 xdoctest = "^1.1.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,7 @@ select = [
     "I",   # isort
     "SIM", # flake8-simplify
     "RUF", # ruff
+    "TCH", # flake8-type-checking
     "Q",   # flake8-quotes
     "W",   # pycodestyle
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,13 +25,11 @@ money = ["py-moneyed"]
 
 [tool.poetry.group.dev.dependencies]
 beautifulsoup4 = "^4.11.2"
-black = "^23.1.0"
 codecov = "^2.1.12"
 coverage = "^7.2.1"
 darglint = "^1.8.1"
 flake8 = "^5.0.4"
 flake8-annotations = "^2.9.1"
-flake8-black = "^0.3.6"
 flake8-bugbear = "^23.2.13"
 flake8-docstrings = "^1.7.0"
 flake8-isort = "^6.0.0"
@@ -42,6 +40,9 @@ py-moneyed = "^3.0"
 pytest = "^7.2.2"
 pytest-cov = "^4.0.0"
 xdoctest = "^1.1.1"
+
+[tool.poetry.group.black.dependencies]
+black = "^23.1.0"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = "^4.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ py-moneyed = { version = ">=0.8", optional = true }
 money = ["py-moneyed"]
 
 [tool.poetry.group.dev.dependencies]
-darglint = "^1.8.1"
 flake8 = "^5.0.4"
 flake8-annotations = "^2.9.1"
 flake8-bugbear = "^23.2.13"
@@ -34,6 +33,9 @@ isort = "^5.11.5"
 
 [tool.poetry.group.black.dependencies]
 black = "^23.1.0"
+
+[tool.poetry.group.darglint.dependencies]
+darglint = "^1.8.1"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = "^4.0.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,6 +99,7 @@ select = [
     "SIM", # flake8-simplify
     "RUF", # ruff
     "TCH", # flake8-type-checking
+    "TID", # flake8-tidy-imports
     "Q",   # flake8-quotes
     "W",   # pycodestyle
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ select = [
     "E",   # pycodestyle
     "F",   # pyflakes
     "I",   # isort
+    "RUF", # ruff
     "W",   # pycodestyle
 ]
 ignore = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,7 @@ select = [
     "E",   # pycodestyle
     "F",   # pyflakes
     "I",   # isort
+    "SIM", # flake8-simplify
     "RUF", # ruff
     "Q",   # flake8-quotes
     "W",   # pycodestyle

--- a/scripts/download_gs1_prefixes.py
+++ b/scripts/download_gs1_prefixes.py
@@ -49,11 +49,11 @@ def parse(html_content: bytes) -> List[_GS1PrefixRange]:
             note_start = usage.index(", see")
             usage = usage[:note_start]
 
-        for range in prefixes.split("&"):
-            if "-" in range:
-                start, end = map(str.strip, range.split("-"))
+        for range_ in prefixes.split("&"):
+            if "-" in range_:
+                start, end = map(str.strip, range_.split("-"))
             else:
-                start, end = range.strip(), range.strip()
+                start, end = range_.strip(), range_.strip()
 
             length = len(start)
             min_value = int(start)

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,35 +7,3 @@ ignore_raise =
     # Exception is used for cases that are bugs and should never happen.
     Exception
 strictness = short
-
-[flake8]
-exclude = .git,.nox,.venv
-max-line-length = 88
-select =
-    # Regular flake8 rules
-    C, E, F, W
-    # flake8-annotations rules
-    ANN
-    # flake8-bugbear rules
-    B
-    # B950: line too long (soft speed limit)
-    B950
-    # flake8-docstrings rules
-    D
-    # flake8-isort rules
-    I
-ignore =
-    # ANN101: Missing type annotation for self in method
-    ANN101
-    # ANN102: Missing type annotation for cls in method
-    ANN102
-    # E203: whitespace before ':' (not PEP8 compliant)
-    E203
-    # E501: line too long (replaced by B950)
-    E501
-    # W503: line break before binary operator (not PEP8 compliant)
-    W503
-per-file-ignores =
-    noxfile.py:ANN
-    tests/*:D
-docstring-convention = google

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,8 +20,6 @@ select =
     B
     # B950: line too long (soft speed limit)
     B950
-    # flake8-black rules
-    BLK
     # flake8-docstrings rules
     D
     # darglint rules

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,6 @@ select =
     B950
     # flake8-docstrings rules
     D
-    # darglint rules
-    DAR
     # flake8-isort rules
     I
 ignore =

--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -55,7 +55,7 @@ raised with a reason from each parser.
 try:
     from importlib.metadata import PackageNotFoundError, version  # type: ignore
 except ImportError:  # pragma: no cover
-    from importlib_metadata import version, PackageNotFoundError  # type: ignore
+    from importlib_metadata import PackageNotFoundError, version  # type: ignore
 
 from biip._exceptions import BiipException, EncodeError, ParseError
 from biip._parser import ParseResult, parse

--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -53,9 +53,15 @@ raised with a reason from each parser.
 """
 
 try:
-    from importlib.metadata import PackageNotFoundError, version  # type: ignore
+    from importlib.metadata import (  # type: ignore[import]
+        PackageNotFoundError,
+        version,
+    )
 except ImportError:  # pragma: no cover
-    from importlib_metadata import PackageNotFoundError, version  # type: ignore
+    from importlib_metadata import (  # type: ignore[import,no-redef]
+        PackageNotFoundError,
+        version,
+    )
 
 from biip._exceptions import BiipException, EncodeError, ParseError
 from biip._parser import ParseResult, parse

--- a/src/biip/_exceptions.py
+++ b/src/biip/_exceptions.py
@@ -3,7 +3,7 @@
 __all__ = ["BiipException", "EncodeError", "ParseError"]
 
 
-class BiipException(Exception):
+class BiipException(Exception):  # noqa: N818
     """Base class for all custom exceptions raised by the library."""
 
     pass

--- a/src/biip/_exceptions.py
+++ b/src/biip/_exceptions.py
@@ -6,16 +6,10 @@ __all__ = ["BiipException", "EncodeError", "ParseError"]
 class BiipException(Exception):  # noqa: N818
     """Base class for all custom exceptions raised by the library."""
 
-    pass
-
 
 class EncodeError(BiipException):
     """Error raised if encoding of a value fails."""
 
-    pass
-
 
 class ParseError(BiipException):
     """Error raised if parsing of barcode data fails."""
-
-    pass

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -90,10 +90,12 @@ def parse(
         (parse_func, val) = queue.pop(0)
         parse_func(val, config=config, queue=queue, result=result)
 
-    if result._has_result():
+    if result._has_result():  # noqa: SLF001
         return result
 
-    raise ParseError(f"Failed to parse {value!r}:\n{result._get_errors_list()}")
+    raise ParseError(
+        f"Failed to parse {value!r}:\n{result._get_errors_list()}"  # noqa: SLF001
+    )
 
 
 @dataclass

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -92,8 +92,8 @@ def parse(
 
     if result._has_result():
         return result
-    else:
-        raise ParseError(f"Failed to parse {value!r}:\n{result._get_errors_list()}")
+
+    raise ParseError(f"Failed to parse {value!r}:\n{result._get_errors_list()}")
 
 
 @dataclass

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -189,7 +189,7 @@ def _parse_gtin(
 def _parse_upc(
     value: str,
     *,
-    config: ParseConfig,
+    config: ParseConfig,  # noqa: ARG001
     queue: ParseQueue,
     result: ParseResult,
 ) -> None:
@@ -210,8 +210,8 @@ def _parse_upc(
 def _parse_sscc(
     value: str,
     *,
-    config: ParseConfig,
-    queue: ParseQueue,
+    config: ParseConfig,  # noqa: ARG001
+    queue: ParseQueue,  # noqa: ARG001
     result: ParseResult,
 ) -> None:
     if result.sscc is not None:

--- a/src/biip/gs1/__init__.py
+++ b/src/biip/gs1/__init__.py
@@ -81,15 +81,12 @@ ASCII_GROUP_SEPARATOR = "\x1d"
 DEFAULT_SEPARATOR_CHARS: Tuple[str] = (ASCII_GROUP_SEPARATOR,)
 
 # The following must be imported in this specific order.
-from biip.gs1._symbology import GS1Symbology  # isort:skip  # noqa: E402
-from biip.gs1._application_identifiers import (  # isort:skip  # noqa: E402
-    GS1ApplicationIdentifier,
-)
-from biip.gs1._prefixes import GS1CompanyPrefix, GS1Prefix  # isort:skip  # noqa: E402
-from biip.gs1._element_strings import (  # isort:skip  # noqa: E402
-    GS1ElementString,
-)
-from biip.gs1._messages import GS1Message  # isort:skip  # noqa: E402
+# ruff: noqa: E402, I001
+from biip.gs1._symbology import GS1Symbology
+from biip.gs1._application_identifiers import GS1ApplicationIdentifier
+from biip.gs1._prefixes import GS1CompanyPrefix, GS1Prefix
+from biip.gs1._element_strings import GS1ElementString
+from biip.gs1._messages import GS1Message
 
 __all__ = [
     "GS1CompanyPrefix",

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -149,14 +149,14 @@ class GS1ElementString:
         value = "".join(pattern_groups)
 
         element = cls(ai=ai, value=value, pattern_groups=pattern_groups)
-        element._set_gln()
-        element._set_gtin(
+        element._set_gln()  # noqa: SLF001
+        element._set_gtin(  # noqa: SLF001
             rcn_region=rcn_region,
             rcn_verify_variable_measure=rcn_verify_variable_measure,
         )
-        element._set_sscc()
-        element._set_date()
-        element._set_decimal()
+        element._set_sscc()  # noqa: SLF001
+        element._set_date()  # noqa: SLF001
+        element._set_decimal()  # noqa: SLF001
 
         return element
 

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -297,14 +297,17 @@ def _get_century(two_digit_year: int) -> int:
     current_century = current_year - current_year % 100
     two_digit_current_year = current_year - current_century
 
+    # Previous century
     if 51 <= two_digit_year - two_digit_current_year <= 99:
-        return current_century - 100  # Previous century
-    elif -99 <= two_digit_year - two_digit_current_year <= -50:
-        # Next century
+        return current_century - 100
+
+    # Next century
+    if -99 <= two_digit_year - two_digit_current_year <= -50:
         # Skipping coverage as this code won't run until year 2051
         return current_century + 100  # pragma: no cover
-    else:
-        return current_century  # Current century
+
+    # Current century
+    return current_century
 
 
 def _get_last_day_of_month(year: int, month: int) -> int:

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -293,7 +293,7 @@ def _get_century(two_digit_year: int) -> int:
     References:
         GS1 General Specifications, section 7.12
     """
-    current_year = datetime.date.today().year
+    current_year = datetime.datetime.now(tz=datetime.timezone.utc).year
     current_century = current_year - current_year % 100
     two_digit_current_year = current_year - current_century
 

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -18,7 +18,7 @@ from biip.sscc import Sscc
 try:
     import moneyed
 except ImportError:  # pragma: no cover
-    moneyed = None  # type: ignore
+    moneyed = None  # type: ignore[assignment]
 
 
 @dataclass

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -82,7 +82,7 @@ class GS1ElementString:
 
     #: A Money value created from the element string, if the AI represents a
     #: currency and an amount. Only set if py-moneyed is installed.
-    money: Optional["moneyed.Money"] = None
+    money: Optional["moneyed.Money"] = None  # noqa: UP037
 
     @classmethod
     def extract(

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -208,10 +208,10 @@ class GS1ElementString:
 
         try:
             self.date = _parse_date(self.value)
-        except ValueError:
+        except ValueError as exc:
             raise ParseError(
                 f"Failed to parse GS1 AI {self.ai} date from {self.value!r}."
-            )
+            ) from exc
 
     def _set_decimal(self) -> None:
         variable_measure = self.ai.ai[:2] in (

--- a/src/biip/gs1/_messages.py
+++ b/src/biip/gs1/_messages.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from itertools import chain
-from typing import Iterable, List, Optional, Union
+from typing import TYPE_CHECKING, Iterable, List, Optional, Union
 
 from biip import ParseError
 from biip.gs1 import (
@@ -15,7 +15,9 @@ from biip.gs1 import (
     GS1ElementString,
 )
 from biip.gs1._application_identifiers import _GS1_APPLICATION_IDENTIFIERS
-from biip.gtin import RcnRegion
+
+if TYPE_CHECKING:  # pragma: no cover
+    from biip.gtin import RcnRegion
 
 
 @dataclass

--- a/src/biip/gs1/_messages.py
+++ b/src/biip/gs1/_messages.py
@@ -192,9 +192,11 @@ class GS1Message:
         result = []
 
         for element_string in self.element_strings:
-            if ai is not None and element_string.ai.ai.startswith(ai):
-                result.append(element_string)
-            elif data_title is not None and data_title in element_string.ai.data_title:
+            ai_match = ai is not None and element_string.ai.ai.startswith(ai)
+            data_title_match = (
+                data_title is not None and data_title in element_string.ai.data_title
+            )
+            if ai_match or data_title_match:
                 result.append(element_string)
 
         return result

--- a/src/biip/gs1/checksums.py
+++ b/src/biip/gs1/checksums.py
@@ -65,10 +65,11 @@ def price_check_digit(value: str) -> int:
 
     if len(value) == 4:
         return _four_digit_price_check_digit(value)
-    elif len(value) == 5:
+
+    if len(value) == 5:
         return _five_digit_price_check_digit(value)
-    else:
-        raise ValueError(f"Expected input of length 4 or 5, got {value!r}.")
+
+    raise ValueError(f"Expected input of length 4 or 5, got {value!r}.")
 
 
 def _four_digit_price_check_digit(value: str) -> int:

--- a/src/biip/gtin/_gtin.py
+++ b/src/biip/gtin/_gtin.py
@@ -141,7 +141,7 @@ class Gtin:
         )
 
         if isinstance(gtin, Rcn) and rcn_region is not None:
-            gtin._parse_with_regional_rules(
+            gtin._parse_with_regional_rules(  # noqa: SLF001
                 region=rcn_region,
                 verify_variable_measure=rcn_verify_variable_measure,
             )

--- a/src/biip/gtin/_rcn.py
+++ b/src/biip/gtin/_rcn.py
@@ -57,7 +57,7 @@ class Rcn(Gtin):
 
     #: A Money value created from the variable weight price.
     #: Only set if py-moneyed is installed and the currency is known.
-    money: Optional["moneyed.Money"] = field(default=None)
+    money: Optional["moneyed.Money"] = field(default=None)  # noqa: UP037
 
     def __post_init__(self) -> None:
         """Initialize derivated fields."""

--- a/src/biip/gtin/_rcn.py
+++ b/src/biip/gtin/_rcn.py
@@ -168,7 +168,7 @@ class _Strategy:
 
         region_rules = _RCN_RULES.get(rcn.region)
         if region_rules is None:
-            raise Exception(  # pragma: no cover
+            raise Exception(  # noqa: TRY002  # pragma: no cover
                 "RCN region defined without defining rules. This is a bug."
             )
 

--- a/src/biip/gtin/_rcn.py
+++ b/src/biip/gtin/_rcn.py
@@ -199,7 +199,7 @@ class _Strategy:
 
     def verify_check_digit(self, rcn: Rcn) -> None:
         if self.check_digit_slice is None:
-            return None
+            return
 
         rcn_13 = rcn.as_gtin_13()
         value = rcn_13[self.value_slice]

--- a/src/biip/gtin/_rcn.py
+++ b/src/biip/gtin/_rcn.py
@@ -14,7 +14,7 @@ from biip.gtin import Gtin, RcnRegion, RcnUsage
 try:
     import moneyed
 except ImportError:  # pragma: no cover
-    moneyed = None  # type: ignore
+    moneyed = None  # type: ignore[assignment]
 
 
 @dataclass

--- a/src/biip/symbology.py
+++ b/src/biip/symbology.py
@@ -178,11 +178,11 @@ class SymbologyIdentifier:
 
         try:
             symbology = Symbology(value[1])
-        except ValueError:
+        except ValueError as exc:
             raise ParseError(
                 f"Failed to get Symbology Identifier from {value!r}. "
                 f"{value[1]!r} is not a recognized code character."
-            )
+            ) from exc
 
         if symbology == Symbology.SYSTEM_EXPANSION:
             modifiers_length = int(value[2]) + 1

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -121,7 +121,8 @@ class Upc:
 
         if length == 12:
             return cls._parse_upc_a(value)
-        elif length in (6, 7, 8):
+
+        if length in (6, 7, 8):
             return cls._parse_upc_e(value)
 
         raise Exception("Unhandled UPC length. This is a bug.")  # pragma: no cover

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -36,7 +36,8 @@ All UPC-E values can be expanded to an UPC-A.
     >>> upc_e.as_upc_a()
     '042100005264'
 
-UPC is a subset of the later GTIN standard: An UPC-A value is also a valid GTIN-12 value.
+UPC is a subset of the later GTIN standard: An UPC-A value is also a valid
+GTIN-12 value.
 
     >>> upc_e.as_gtin_12()
     '042100005264'

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -125,7 +125,9 @@ class Upc:
         if length in (6, 7, 8):
             return cls._parse_upc_e(value)
 
-        raise Exception("Unhandled UPC length. This is a bug.")  # pragma: no cover
+        raise Exception(  # noqa: TRY002  # pragma: no cover
+            "Unhandled UPC length. This is a bug."
+        )
 
     @classmethod
     def _parse_upc_a(cls, value: str) -> Upc:
@@ -173,7 +175,7 @@ class Upc:
             payload = value[:-1]
             check_digit = int(value[-1])
         else:
-            raise Exception(  # pragma: no cover
+            raise Exception(  # noqa: TRY002  # pragma: no cover
                 "Unhandled UPC-E length. This is a bug."
             )
 
@@ -216,7 +218,7 @@ class Upc:
         if self.format == UpcFormat.UPC_E:
             return _upc_e_to_upc_a_expansion(f"{self.payload}{self.check_digit}")
 
-        raise Exception(  # pragma: no cover
+        raise Exception(  # noqa: TRY002  # pragma: no cover
             "Unhandled case while formatting as UPC-A. This is a bug."
         )
 
@@ -238,7 +240,7 @@ class Upc:
         if self.format == UpcFormat.UPC_E:
             return f"{self.payload}{self.check_digit}"
 
-        raise Exception(  # pragma: no cover
+        raise Exception(  # noqa: TRY002  # pragma: no cover
             "Unhandled case while formatting as UPC-E. This is a bug."
         )
 
@@ -280,7 +282,7 @@ def _upc_e_to_upc_a_expansion(value: str) -> str:
     if last_digit in (5, 6, 7, 8, 9):
         return f"{value[:6]}0000{last_digit}{check_digit}"
 
-    raise Exception(  # pragma: no cover
+    raise Exception(  # noqa: TRY002  # pragma: no cover
         "Unhandled case while expanding UPC-E to UPC-A. This is a bug."
     )
 

--- a/tests/gs1/test_application_identifiers.py
+++ b/tests/gs1/test_application_identifiers.py
@@ -16,7 +16,7 @@ def test_extract_unknown_gs1_ai(unknown_ai: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (
             "0195012345678903",

--- a/tests/gs1/test_checksums.py
+++ b/tests/gs1/test_checksums.py
@@ -5,14 +5,15 @@ from biip.gs1.checksums import numeric_check_digit, price_check_digit
 
 @pytest.mark.parametrize("value", ["abc", "⁰⁰⁰"])
 def test_numeric_check_digit_with_nonnumeric_value(value: str) -> None:
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ValueError,
+        match=rf"^Expected numeric value, got {value!r}.$",
+    ):
         numeric_check_digit(value)
-
-    assert str(exc_info.value) == f"Expected numeric value, got {value!r}."
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         # Example from reference
         ("37610425002123456", 9),
@@ -32,10 +33,11 @@ def test_numeric_check_digit(value: str, expected: int) -> None:
 
 @pytest.mark.parametrize("value", ["abc", "⁰⁰⁰"])
 def test_price_check_digit_with_nonnumeric_value(value: str) -> None:
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ValueError,
+        match=rf"^Expected numeric value, got {value!r}.$",
+    ):
         price_check_digit(value)
-
-    assert str(exc_info.value) == f"Expected numeric value, got {value!r}."
 
 
 @pytest.mark.parametrize(
@@ -48,14 +50,15 @@ def test_price_check_digit_with_nonnumeric_value(value: str) -> None:
     ],
 )
 def test_price_check_digit_on_values_with_wrong_length(value: str) -> None:
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ValueError,
+        match=rf"^Expected input of length 4 or 5, got {value!r}.$",
+    ):
         price_check_digit(value)
-
-    assert str(exc_info.value) == f"Expected input of length 4 or 5, got {value!r}."
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         # Four-digit price field
         ("2875", 9),

--- a/tests/gs1/test_element_strings.py
+++ b/tests/gs1/test_element_strings.py
@@ -17,7 +17,7 @@ from biip.sscc import Sscc
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (
             "00373400306809981733",
@@ -89,7 +89,7 @@ def test_extract(value: str, expected: GS1ElementString) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (  # GS1 element string with invalid GLN
             "4101234567890127",
@@ -136,7 +136,7 @@ def test_extract_with_nested_error(value: str, expected: GS1ElementString) -> No
 
 
 @pytest.mark.parametrize(
-    "ai_code, bad_value",
+    ("ai_code", "bad_value"),
     [
         # Too short product number
         ("01", "01123"),
@@ -157,7 +157,7 @@ def test_extract_fails_when_not_matching_pattern(ai_code: str, bad_value: str) -
 
 
 @pytest.mark.parametrize(
-    "ai_code, bad_value",
+    ("ai_code", "bad_value"),
     [
         # Bad production date
         ("11", "131313"),
@@ -185,7 +185,7 @@ MAX_YEAR_SHORT = str(MAX_YEAR)[2:]
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (
             # Best before date, around the current date
@@ -226,7 +226,7 @@ def test_extract_handles_min_and_max_year_correctly(
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         ("15200200", date(2020, 2, 29)),
         ("15210200", date(2021, 2, 28)),
@@ -240,7 +240,7 @@ def test_extract_handles_zero_day_as_last_day_of_month(
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         # Trade measures (GS1 General Specifications, section 3.6.2)
         ("3105123456", Decimal("1.23456")),  # Net weight (kg)
@@ -273,7 +273,7 @@ def test_extract_variable_measures(value: str, expected: Decimal) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         # Amount payable or coupon value (GS1 General Specifications, section 3.6.6)
         ("3901123", Decimal("12.3")),
@@ -295,7 +295,7 @@ def test_extract_amount_payable(value: str, expected: Decimal) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected_currency, expected_decimal",
+    ("value", "expected_currency", "expected_decimal"),
     [
         # Amount payable and ISO currency code (section 3.6.7)
         ("39127101230", "ZAR", Decimal("12.30")),
@@ -328,7 +328,7 @@ def test_extract_amount_payable_and_currency(
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         ("39400010", Decimal("10")),
         ("39410055", Decimal("5.5")),
@@ -339,7 +339,7 @@ def test_extract_percentage_discount(value: str, expected: Decimal) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected", [("0107032069804988", "(01)07032069804988")]
+    ("value", "expected"), [("0107032069804988", "(01)07032069804988")]
 )
 def test_as_hri(value: str, expected: str) -> None:
     assert GS1ElementString.extract(value).as_hri() == expected

--- a/tests/gs1/test_element_strings.py
+++ b/tests/gs1/test_element_strings.py
@@ -99,7 +99,7 @@ def test_extract(value: str, expected: GS1ElementString) -> None:
                 pattern_groups=["1234567890127"],
                 gln=None,  # Not set, because GLN is invalid.
                 gln_error=(
-                    "Invalid GLN check digit for '1234567890127': " "Expected 8, got 7."
+                    "Invalid GLN check digit for '1234567890127': Expected 8, got 7."
                 ),
             ),
         ),

--- a/tests/gs1/test_element_strings.py
+++ b/tests/gs1/test_element_strings.py
@@ -1,3 +1,4 @@
+import datetime
 from datetime import date
 from decimal import Decimal
 
@@ -175,7 +176,7 @@ def test_extract_fails_with_invalid_date(ai_code: str, bad_value: str) -> None:
     )
 
 
-THIS_YEAR = date.today().year
+THIS_YEAR = datetime.datetime.now(tz=datetime.timezone.utc).year
 THIS_YEAR_SHORT = str(THIS_YEAR)[2:]
 MIN_YEAR = THIS_YEAR - 49
 MIN_YEAR_SHORT = str(MIN_YEAR)[2:]

--- a/tests/gs1/test_messages.py
+++ b/tests/gs1/test_messages.py
@@ -104,7 +104,7 @@ def test_parse(value: str, expected: GS1Message) -> None:
             # Unrealistic corner case just to exercise the code:
             # Two variable-length fields marked with different separators
             "0107032069804988100329|2112345\x1d15210526",
-            ["|"] + list(DEFAULT_SEPARATOR_CHARS),
+            ["|", *DEFAULT_SEPARATOR_CHARS],
             "(01)07032069804988(10)0329(21)12345(15)210526",
         ),
     ],

--- a/tests/gs1/test_messages.py
+++ b/tests/gs1/test_messages.py
@@ -17,7 +17,7 @@ from biip.gtin import Gtin, GtinFormat, Rcn, RcnRegion
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (
             "010703206980498815210526100329",
@@ -71,7 +71,7 @@ def test_parse(value: str, expected: GS1Message) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, separator_chars, expected_hri",
+    ("value", "separator_chars", "expected_hri"),
     [
         (
             # Variable-length lot number field last, all OK.
@@ -119,13 +119,14 @@ def test_parse_with_separator_char(
 
 
 def test_parse_with_too_long_separator_char_fails() -> None:
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ValueError,
+        match=(
+            r"^All separator characters must be exactly 1 character long, "
+            r"got \['--'\].$"
+        ),
+    ):
         GS1Message.parse("10222--15210526", separator_chars=["--"])
-
-    assert (
-        str(exc_info.value)
-        == "All separator characters must be exactly 1 character long, got ['--']."
-    )
 
 
 def test_parse_fails_if_unparsed_data_left() -> None:
@@ -163,7 +164,7 @@ def test_parse_strips_surrounding_whitespace() -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (
             "(17)221231",
@@ -291,7 +292,7 @@ def test_parse_hri_fails_if_ai_is_unknown(value: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (
             "010703206980498815210526100329",
@@ -304,7 +305,7 @@ def test_as_hri(value: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, ai, expected",
+    ("value", "ai", "expected"),
     [
         ("010703206980498815210526100329", "01", ["07032069804988"]),
         ("010703206980498815210526100329", "15", ["210526"]),
@@ -324,7 +325,7 @@ def test_filter_element_strings_by_ai(value: str, ai: str, expected: List[str]) 
 
 
 @pytest.mark.parametrize(
-    "value, data_title, expected",
+    ("value", "data_title", "expected"),
     [
         ("010703206980498815210526100329", "GTIN", ["07032069804988"]),
         ("010703206980498815210526100329", "BEST BY", ["210526"]),
@@ -345,7 +346,7 @@ def test_filter_element_strings_by_data_title(
 
 
 @pytest.mark.parametrize(
-    "value, ai, expected",
+    ("value", "ai", "expected"),
     [
         ("010703206980498815210526100329", "01", "07032069804988"),
         ("010703206980498815210526100329", "15", "210526"),
@@ -366,7 +367,7 @@ def test_get_element_string_by_ai(value: str, ai: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, data_title, expected",
+    ("value", "data_title", "expected"),
     [
         ("010703206980498815210526100329", "GTIN", "07032069804988"),
         ("010703206980498815210526100329", "BEST BY", "210526"),

--- a/tests/gs1/test_prefixes.py
+++ b/tests/gs1/test_prefixes.py
@@ -15,7 +15,7 @@ def test_invalid_gs1_prefix(bad_value: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (
             "0000001999",
@@ -49,7 +49,7 @@ def test_invalid_gs1_company_prefix(bad_value: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (
             # Undefined prefix

--- a/tests/gtin/test_encode.py
+++ b/tests/gtin/test_encode.py
@@ -7,7 +7,7 @@ from biip.gtin import Gtin
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         # GTIN-8
         ("96385074", "00000096385074"),
@@ -29,7 +29,7 @@ def test_as_gtin_14(value: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         # GTIN-8
         ("96385074", "0000096385074"),
@@ -65,7 +65,7 @@ def test_as_gtin_13_fails_for_too_long_values(value: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         # GTIN-8
         ("96385074", "000096385074"),
@@ -102,7 +102,7 @@ def test_as_gtin_12_fails_for_too_long_values(value: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         # GTIN-8
         ("96385074", "96385074"),

--- a/tests/gtin/test_rcn.py
+++ b/tests/gtin/test_rcn.py
@@ -4,7 +4,7 @@ from biip.gtin import Gtin, GtinFormat, Rcn, RcnRegion, RcnUsage
 
 
 @pytest.mark.parametrize(
-    "value, gtin_format, rcn_usage",
+    ("value", "gtin_format", "rcn_usage"),
     [
         # RCN-8
         ("00011112", GtinFormat.GTIN_8, RcnUsage.COMPANY),
@@ -55,7 +55,7 @@ def test_gtin_14_with_rcn_prefix_is_not_an_rcn() -> None:
 
 
 @pytest.mark.parametrize(
-    "value, rcn_region",
+    ("value", "rcn_region"),
     [
         ("de", RcnRegion.GERMANY),
         ("dk", RcnRegion.DENMARK),
@@ -81,13 +81,14 @@ def test_rcn_region_can_be_specified_as_string(
 
 
 def test_fails_when_rcn_region_is_unknown_string() -> None:
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ValueError,
+        match=r"^'foo' is not a valid RcnRegion$",
+    ):
         Gtin.parse(
             "2311111112345",
             rcn_region="foo",  # type: ignore
         )
-
-    assert str(exc_info.value) == "'foo' is not a valid RcnRegion"
 
 
 def test_rcn_usage_repr() -> None:

--- a/tests/gtin/test_rcn.py
+++ b/tests/gtin/test_rcn.py
@@ -73,7 +73,7 @@ def test_rcn_region_can_be_specified_as_string(
 ) -> None:
     rcn = Gtin.parse(
         "0211111111114",
-        rcn_region=value,  # type: ignore
+        rcn_region=value,  # type: ignore[arg-type]
     )
 
     assert isinstance(rcn, Rcn)
@@ -87,7 +87,7 @@ def test_fails_when_rcn_region_is_unknown_string() -> None:
     ):
         Gtin.parse(
             "2311111112345",
-            rcn_region="foo",  # type: ignore
+            rcn_region="foo",  # type: ignore[arg-type]
         )
 
 

--- a/tests/gtin/test_rcn.py
+++ b/tests/gtin/test_rcn.py
@@ -4,7 +4,7 @@ from biip.gtin import Gtin, GtinFormat, Rcn, RcnRegion, RcnUsage
 
 
 @pytest.mark.parametrize(
-    "value, format, usage",
+    "value, gtin_format, rcn_usage",
     [
         # RCN-8
         ("00011112", GtinFormat.GTIN_8, RcnUsage.COMPANY),
@@ -20,14 +20,14 @@ from biip.gtin import Gtin, GtinFormat, Rcn, RcnRegion, RcnUsage
     ],
 )
 def test_gtin_parse_may_return_rcn_instance(
-    value: str, format: GtinFormat, usage: RcnUsage
+    value: str, gtin_format: GtinFormat, rcn_usage: RcnUsage
 ) -> None:
     rcn = Gtin.parse(value, rcn_region=RcnRegion.SWEDEN)
 
     assert isinstance(rcn, Rcn)
-    assert rcn.format == format
-    assert rcn.usage == usage
-    if usage == RcnUsage.GEOGRAPHICAL:
+    assert rcn.format == gtin_format
+    assert rcn.usage == rcn_usage
+    if rcn_usage == RcnUsage.GEOGRAPHICAL:
         assert rcn.region == RcnRegion.SWEDEN
     else:
         assert rcn.region is None

--- a/tests/gtin/test_rcn_rules.py
+++ b/tests/gtin/test_rcn_rules.py
@@ -10,7 +10,7 @@ from biip.gtin import Gtin, GtinFormat, Rcn, RcnRegion, RcnUsage
 
 
 @pytest.mark.parametrize(
-    "rcn_region, value, weight, price, money",
+    ("rcn_region", "value", "weight", "price", "money"),
     [
         # NOTE: These examples are constructed from a template. This should be
         # extended with actual examples from either specifications or real
@@ -55,7 +55,7 @@ def test_region_baltics(
 
 
 @pytest.mark.parametrize(
-    "value, weight, price, money",
+    ("value", "weight", "price", "money"),
     [
         ("2135040039753", None, Decimal("39.75"), Money("39.75", "DKK")),
         ("2235040039750", None, Decimal("39.75"), Money("39.75", "DKK")),
@@ -87,7 +87,7 @@ def test_region_denmark(
 
 
 @pytest.mark.parametrize(
-    "value, weight, price, money",
+    ("value", "weight", "price", "money"),
     [
         ("2388060112344", Decimal("1.234"), None, None),
         ("2488060112341", Decimal("12.34"), None, None),
@@ -114,7 +114,7 @@ def test_region_finland(
 
 
 @pytest.mark.parametrize(
-    "value, weight, count, price, money",
+    ("value", "weight", "count", "price", "money"),
     [
         # Money
         ("2211114002394", None, None, Decimal("2.39"), Money("2.39", "EUR")),
@@ -190,7 +190,7 @@ def test_region_germany_when_not_verifying_invalid_check_digit() -> None:
 
 
 @pytest.mark.parametrize(
-    "value, weight, price, money",
+    ("value", "weight", "price", "money"),
     [
         # NOTE: These examples are constructed from a template. This should be
         # extended with actual examples from either specifications or real
@@ -254,7 +254,7 @@ def test_region_great_britain_when_not_verifying_invalid_check_digit() -> None:
 
 
 @pytest.mark.parametrize(
-    "value, weight, price, money",
+    ("value", "weight", "price", "money"),
     [
         ("2302148210869", Decimal("1.086"), None, None),  # Norvegia 1kg
         ("2368091402263", Decimal("0.226"), None, None),  # Stange kyllingbryst
@@ -279,7 +279,7 @@ def test_region_norway(
 
 
 @pytest.mark.parametrize(
-    "value, weight, price, money",
+    ("value", "weight", "price", "money"),
     [
         ("2088060112343", None, Decimal("12.34"), Money("12.34", "SEK")),
         ("2188060112340", None, Decimal("123.4"), Money("123.4", "SEK")),

--- a/tests/gtin/test_without_variable_measure.py
+++ b/tests/gtin/test_without_variable_measure.py
@@ -8,7 +8,7 @@ from biip.gtin import Gtin, Rcn, RcnRegion
 
 
 @pytest.mark.parametrize(
-    "rcn_region, value, expected",
+    ("rcn_region", "value", "expected"),
     [
         (RcnRegion.DENMARK, "2712341002251", "2712341000004"),  # GTIN-13
         (RcnRegion.DENMARK, "02712341002251", "2712341000004"),  # GTIN-14
@@ -37,7 +37,7 @@ def test_without_variable_measure_strips_variable_parts(
 
 
 @pytest.mark.parametrize(
-    "rcn_region, nonvariable_prefixes",
+    ("rcn_region", "nonvariable_prefixes"),
     [
         (
             RcnRegion.DENMARK,
@@ -94,7 +94,7 @@ def test_without_variable_measure_keeps_nonvariable_rcn_unchanged(
 
 
 @pytest.mark.parametrize(
-    "rcn_region, value",
+    ("rcn_region", "value"),
     [
         (RcnRegion.NORWAY, "00012348"),  # GTIN-8
         (RcnRegion.NORWAY, "412345678903"),  # GTIN-12

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -19,7 +19,7 @@ from biip.upc import Upc, UpcFormat
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (
             # GTIN-8

--- a/tests/test_sscc.py
+++ b/tests/test_sscc.py
@@ -58,7 +58,7 @@ def test_parse_with_invalid_check_digit() -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         ("157035381410375177", "1 5703538 141037517 7"),
         ("357081300469846950", "3 5708130 046984695 0"),
@@ -76,21 +76,18 @@ def test_as_hri(value: str, expected: str) -> None:
 def test_as_hri_with_too_low_company_prefix_length() -> None:
     sscc = Sscc.parse("376130321109103420")
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ValueError,
+        match=r"^Expected company prefix length between 7 and 10, got 6.$",
+    ):
         sscc.as_hri(company_prefix_length=6)
-
-    assert (
-        str(exc_info.value) == "Expected company prefix length between 7 and 10, got 6."
-    )
 
 
 def test_as_hri_with_too_high_company_prefix_length() -> None:
     sscc = Sscc.parse("376130321109103420")
 
-    with pytest.raises(ValueError) as exc_info:
+    with pytest.raises(
+        ValueError,
+        match=r"^Expected company prefix length between 7 and 10, got 11.$",
+    ):
         sscc.as_hri(company_prefix_length=11)
-
-    assert (
-        str(exc_info.value)
-        == "Expected company prefix length between 7 and 10, got 11."
-    )

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -10,7 +10,7 @@ def test_symbology_enum() -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (
             "]E0abc",

--- a/tests/upc/test_encode.py
+++ b/tests/upc/test_encode.py
@@ -7,7 +7,7 @@ from biip.upc import Upc
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (  # UPC-A to UPC-A
             "123456789012",
@@ -36,7 +36,7 @@ def test_as_upc_a(value: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (  # 6-digit UPC-E, implicit number system 0, no check digit.
             "425261",
@@ -80,7 +80,7 @@ def test_as_upc_e_when_suppression_is_not_possible() -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         ("425261", "042100005264"),  # UPC-E, 6 digit
         ("0425261", "042100005264"),  # UPC-E, 7 digit
@@ -93,7 +93,7 @@ def test_as_gtin_12(value: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         ("425261", "0042100005264"),  # UPC-E, 6 digit
         ("0425261", "0042100005264"),  # UPC-E, 7 digit
@@ -106,7 +106,7 @@ def test_as_gtin_13(value: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         ("425261", "00042100005264"),  # UPC-E, 6 digit
         ("0425261", "00042100005264"),  # UPC-E, 7 digit

--- a/tests/upc/test_parse.py
+++ b/tests/upc/test_parse.py
@@ -19,7 +19,7 @@ def test_parse_upc_a() -> None:
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         (
             "425261",  # Length is 6: Implicit number system 0, no check digit.


### PR DESCRIPTION
### Poetry dependency groups

Biip now uses `poetry` dependency groups to only define dependencies once, and then reference the groups of dependencies needed for each `nox` session.

### Ruff linter

Biip has switched out `flake8` and `isort` for `ruff`, and enabled a whole lot of new linting rules. The total set of changes required to pass the new rules is quite limited, so they match pretty well the existing code style. This will hopefully help maintain that code style over time.
