### PR TITLE
Upgrade dev deps, require Python 3.8

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: "3.11"
-      - run: pip install nox==2022.11.21 poetry==1.4.2
+      - run: pip install nox==2023.4.22 poetry==1.5.1
       - run: nox --python 3.11
       - run: poetry build
       - run: poetry publish --username=__token__ --password=${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
-      - run: pip install nox==2022.11.21 poetry==1.4.2
+      - run: pip install nox==2023.4.22 poetry==1.5.1
       - run: nox --python ${{ matrix.python-version }}
       - uses: codecov/codecov-action@v3
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     name: Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ see the [documentation](https://biip.readthedocs.io/).
 
 ## Installation
 
-Biip requires Python 3.7 or newer.
+Biip requires Python 3.8 or newer.
 
 Biip is available from [PyPI](https://pypi.org/project/biip/):
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -22,7 +22,7 @@ For details on how the barcode data is interpreted, please refer to the
 Installation
 ============
 
-Biip requires Python 3.7 or newer.
+Biip requires Python 3.8 or newer.
 
 Biip is available from `PyPI <https://pypi.org/project/biip/>`_:
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -5,7 +5,7 @@ import nox
 package = "biip"
 locations = ["src", "tests", "noxfile.py", "docs/conf.py", "scripts"]
 
-supported_pythons = ["3.7", "3.8", "3.9", "3.10", "3.11"]
+supported_pythons = ["3.8", "3.9", "3.10", "3.11"]
 docs_python = "3.11"
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,10 @@ darglint = "^1.8.1"
 
 [tool.poetry.group.dev.dependencies]
 beautifulsoup4 = "^4.12.2"
-httpx = "^0.24.0"
-nox = "^2022.11.21"
+httpx = "^0.24.1"
+nox = "^2023.4.22"
 py-moneyed = "^3.0"
-types-beautifulsoup4 = "^4.12.0.3"
+types-beautifulsoup4 = "^4.12.0.5"
 
 [tool.poetry.group.docs.dependencies]
 sphinx = ">=4,<6"
@@ -42,13 +42,13 @@ sphinx-rtd-theme = "^1.2.0"
 sphinx-autodoc-typehints = "^1.22"
 
 [tool.poetry.group.mypy.dependencies]
-mypy = "^1.2.0"
+mypy = "^1.3.0"
 
 [tool.poetry.group.pyright.dependencies]
-pyright = "^1.1.302"
+pyright = "^1.1.311"
 
 [tool.poetry.group.ruff.dependencies]
-ruff = "^0.0.261"
+ruff = "^0.0.270"
 
 [tool.poetry.group.tests.dependencies]
 coverage = { extras = ["toml"], version = "^7.2.3" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,7 @@ classifiers = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7.0"
-importlib_metadata = { version = ">=1.6,<6.0", python = "<3.8" }
+python = "^3.8.0"
 py-moneyed = { version = ">=0.8", optional = true }
 
 [tool.poetry.extras]
@@ -57,7 +56,7 @@ pytest-cov = "^4.0.0"
 xdoctest = "^1.1.1"
 
 [tool.black]
-target-version = ["py37", "py38", "py39", "py310", "py311"]
+target-version = ["py38", "py39", "py310", "py311"]
 
 [tool.coverage.paths]
 source = ["src"]
@@ -136,7 +135,7 @@ ignore = [
     "UP006", # deprecated-collection-type
     "UP007", # typing-union
 ]
-target-version = "py37"
+target-version = "py38"
 
 [tool.ruff.per-file-ignores]
 "docs/*" = ["INP001"]
@@ -150,7 +149,7 @@ known-first-party = ["biip"]
 convention = "google"
 
 [tool.pyright]
-pythonVersion = "3.7"
+pythonVersion = "3.8"
 venvPath = "."
 venv = ".venv"
 typeCheckingMode = "strict"

--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -54,13 +54,13 @@ raised with a reason from each parser.
 
 try:
     from importlib.metadata import (  # type: ignore[import]
-        PackageNotFoundError,
-        version,  # pyright: reportUnknownVariableType=false
+        PackageNotFoundError,  # pyright: ignore[reportUnknownVariableType]
+        version,  # pyright: ignore[reportUnknownVariableType]
     )
 except ImportError:  # pragma: no cover
     from importlib_metadata import (  # type: ignore[import,no-redef,assignment]
-        PackageNotFoundError,
-        version,
+        PackageNotFoundError,  # pyright: ignore[reportUnknownVariableType]
+        version,  # pyright: ignore[reportUnknownVariableType]
     )
 
 from biip._exceptions import BiipException, EncodeError, ParseError
@@ -76,6 +76,6 @@ __all__ = [
 
 
 try:
-    __version__: str = version(__name__)
+    __version__: str = version(__name__)  # pyright: ignore[reportUnknownVariableType]
 except PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"

--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -52,16 +52,10 @@ raised with a reason from each parser.
     - GS1: Failed to match '123' with GS1 AI (12) pattern '^12(\d{6})$'.
 """
 
-try:
-    from importlib.metadata import (  # type: ignore[import]
-        PackageNotFoundError,  # pyright: ignore[reportUnknownVariableType]
-        version,  # pyright: ignore[reportUnknownVariableType]
-    )
-except ImportError:  # pragma: no cover
-    from importlib_metadata import (  # type: ignore[import,no-redef,assignment]
-        PackageNotFoundError,  # pyright: ignore[reportUnknownVariableType]
-        version,  # pyright: ignore[reportUnknownVariableType]
-    )
+from importlib.metadata import (  # pyright: ignore[reportMissingImports]
+    PackageNotFoundError,  # pyright: ignore[reportUnknownVariableType]
+    version,  # pyright: ignore[reportUnknownVariableType]
+)
 
 from biip._exceptions import BiipException, EncodeError, ParseError
 from biip._parser import ParseResult, parse


### PR DESCRIPTION
Python 3.7 reaches end of life in three weeks, so the next release of Biip will require Python 3.8 or greater.
