### PR TITLE
Replace Black with 'ruff format'

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -25,18 +25,18 @@ def tests(session: nox.Session) -> None:
 
 
 @nox.session(python=supported_pythons)
-def black(session: nox.Session) -> None:
-    """Check formatting using Black."""
+def ruff_format(session: nox.Session) -> None:
+    """Check formatting using Ruff."""
     args = session.posargs or locations
     session.run(
-        "poetry", "install", "--quiet", "--no-root", "--only=black", external=True
+        "poetry", "install", "--quiet", "--no-root", "--only=ruff", external=True
     )
-    session.run("black", *args)
+    session.run("ruff", "format", "--check", *args)
 
 
 @nox.session(python=supported_pythons)
-def ruff(session: nox.Session) -> None:
-    """Lint using ruff."""
+def ruff_lint(session: nox.Session) -> None:
+    """Lint using Ruff."""
     args = session.posargs or locations
     session.run(
         "poetry", "install", "--quiet", "--no-root", "--only=ruff", external=True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ mypy = "^1.5.1"
 pyright = "^1.1.329"
 
 [tool.poetry.group.ruff.dependencies]
-ruff = "^0.0.292"
+ruff = "^0.1.4"
 
 [tool.poetry.group.tests.dependencies]
 coverage = { extras = ["toml"], version = "^7.3.2" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,6 @@ py-moneyed = { version = ">=0.8", optional = true }
 [tool.poetry.extras]
 money = ["py-moneyed"]
 
-[tool.poetry.group.black.dependencies]
-black = "^23.9.1"
-
 [tool.poetry.group.darglint.dependencies]
 darglint = "^1.8.1"
 
@@ -54,9 +51,6 @@ coverage = { extras = ["toml"], version = "^7.3.2" }
 pytest = "^7.4.2"
 pytest-cov = "^4.1.0"
 xdoctest = "^1.1.1"
-
-[tool.black]
-target-version = ["py38", "py39", "py310", "py311", "py312"]
 
 [tool.coverage.paths]
 source = ["src"]
@@ -127,6 +121,7 @@ ignore = [
     "A003",    # builtin-attribute-shadowing
     "ANN101",  # missing-type-self
     "ANN102",  # missing-type-cls
+    "ISC001",  # single-line-implicit-string-concatenation
     "PLR2004", # magic-value-comparison
     "RET504",  # unnecessary-assign
     "TRY003",  # raise-vanilla-args


### PR DESCRIPTION
- Bump ruff from 0.0.292 to 0.1.4
- Replace Black with 'ruff format'
