### PR TITLE
 Skip unmatching optional pattern groups

### DIFF
--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -147,7 +147,7 @@ class GS1ElementString:
         if not matches:
             msg = f"Failed to match {value!r} with GS1 AI {ai} pattern '{ai.pattern}'."
             raise ParseError(msg)
-        pattern_groups = list(matches.groups())
+        pattern_groups = [group for group in matches.groups() if group is not None]
         value = "".join(pattern_groups)
 
         element = cls(ai=ai, value=value, pattern_groups=pattern_groups)

--- a/tests/gs1/test_element_strings.py
+++ b/tests/gs1/test_element_strings.py
@@ -76,6 +76,22 @@ from biip.sscc import Sscc
             ),
         ),
         (
+            "7011030102",  # Without optional pattern group for time
+            GS1ElementString(
+                ai=GS1ApplicationIdentifier.extract("7011"),
+                value="030102",
+                pattern_groups=["030102"],
+            ),
+        ),
+        (
+            "70110301021430",  # With optional pattern group for time
+            GS1ElementString(
+                ai=GS1ApplicationIdentifier.extract("7011"),
+                value="0301021430",
+                pattern_groups=["030102", "1430"],
+            ),
+        ),
+        (
             "800307071324001022085952",
             GS1ElementString(
                 ai=GS1ApplicationIdentifier.extract("8003"),

--- a/tests/gs1/test_messages.py
+++ b/tests/gs1/test_messages.py
@@ -129,16 +129,25 @@ def test_parse_with_too_long_separator_char_fails() -> None:
         GS1Message.parse("10222--15210526", separator_chars=["--"])
 
 
-def test_parse_fails_if_unparsed_data_left() -> None:
-    # 10 = AI for BATCH/LOT
-    # 222... = Max length BATCH/LOT
-    # aaa = Superflous data
-    value = "1022222222222222222222aaa"
-
+@pytest.mark.parametrize(
+    ("value", "error"),
+    [
+        # 10 = AI for BATCH/LOT
+        # 222... = Max length BATCH/LOT
+        # aaa = Superflous data
+        (
+            "1022222222222222222222aaa",
+            "Failed to get GS1 Application Identifier from 'aaa'.",
+        ),
+        # Too short to match optional time group (as this is really a GTIN-13)
+        ("701197206489", "Failed to get GS1 Application Identifier from '89'."),
+    ],
+)
+def test_parse_fails_if_unparsed_data_left(value: str, error: str) -> None:
     with pytest.raises(ParseError) as exc_info:
         GS1Message.parse(value)
 
-    assert str(exc_info.value) == "Failed to get GS1 Application Identifier from 'aaa'."
+    assert str(exc_info.value) == error
 
 
 def test_parse_fails_if_fixed_length_field_ends_with_separator_char() -> None:


### PR DESCRIPTION
In the latest GS1 Application Identifier dataset, there are four AIs
with optional pattern groups. When the value matches everything but the
optional pattern group, the group's value becomes `None`. This caused
Biip to crash when we tried building a string of the characters
matching the pattern.

Fixes #295