### PR TITLE
Extract date and datetime from more GS1 AIs

### DIFF
--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -17,8 +17,8 @@ example, the value can be interpreted as either a GTIN or a GS1 Message.
     description='Company internal information', data_title='INTERNAL',
     fnc1_required=True, format='N2+X..90'), value='385074',
     pattern_groups=['385074'], gln=None, gln_error=None, gtin=None,
-    gtin_error=None, sscc=None, sscc_error=None, date=None, decimal=None,
-    money=None)])
+    gtin_error=None, sscc=None, sscc_error=None, date=None, datetime=None,
+    decimal=None, money=None)])
 
 In the next example, the value is only valid as a GS1 Message and the GTIN
 parser returns an error explaining why the value cannot be interpreted as a
@@ -37,7 +37,7 @@ the check digits are incorrect.
     BY', fnc1_required=False, format='N2+N6'), value='210527',
     pattern_groups=['210527'], gln=None, gln_error=None, gtin=None,
     gtin_error=None, sscc=None, sscc_error=None, date=datetime.date(2021, 5,
-    27), decimal=None, money=None)])
+    27), datetime=None, decimal=None, money=None)])
 
 If a value cannot be interpreted as any supported format, an exception is
 raised with a reason from each parser.

--- a/src/biip/gs1/__init__.py
+++ b/src/biip/gs1/__init__.py
@@ -48,8 +48,8 @@ In this example, the first element string is a GTIN.
     format=GtinFormat.GTIN_13, prefix=GS1Prefix(value='703', usage='GS1
     Norway'), company_prefix=GS1CompanyPrefix(value='703206'),
     payload='703206980498', check_digit=8, packaging_level=None),
-    gtin_error=None, sscc=None, sscc_error=None, date=None, decimal=None,
-    money=None)
+    gtin_error=None, sscc=None, sscc_error=None, date=None, datetime=None,
+    decimal=None, money=None)
 
 The message object has :meth:`~GS1Message.get` and :meth:`~GS1Message.filter`
 methods to lookup element strings either by the Application Identifier's
@@ -61,13 +61,13 @@ methods to lookup element strings either by the Application Identifier's
     fnc1_required=False, format='N2+N6'), value='210526',
     pattern_groups=['210526'], gln=None, gln_error=None, gtin=None,
     gtin_error=None, sscc=None, sscc_error=None, date=datetime.date(2021, 5,
-    26), decimal=None, money=None)
+    26), datetime=None, decimal=None, money=None)
     >>> msg.get(ai="10")
     GS1ElementString(ai=GS1ApplicationIdentifier(ai='10', description='Batch
     or lot number', data_title='BATCH/LOT', fnc1_required=True,
     format='N2+X..20'), value='0329', pattern_groups=['0329'], gln=None,
     gln_error=None, gtin=None, gtin_error=None, sscc=None, sscc_error=None,
-    date=None, decimal=None, money=None)
+    date=None, datetime=None, decimal=None, money=None)
 """
 
 from typing import Tuple

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -44,7 +44,7 @@ class GS1ElementString:
         prefix=GS1Prefix(value='703', usage='GS1 Norway'),
         company_prefix=GS1CompanyPrefix(value='703206'), payload='703206980498',
         check_digit=8, packaging_level=None), gtin_error=None, sscc=None,
-        sscc_error=None, date=None, decimal=None, money=None)
+        sscc_error=None, date=None, datetime=None, decimal=None, money=None)
         >>> element_string.as_hri()
         '(01)07032069804988'
     """
@@ -78,6 +78,9 @@ class GS1ElementString:
 
     #: A date created from the element string, if the AI represents a date.
     date: Optional[dt.date] = None
+
+    #: A datetime created from the element string, if the AI represents a datetime.
+    datetime: Optional[dt.datetime] = None
 
     #: A decimal value created from the element string, if the AI represents a number.
     decimal: Optional[Decimal] = None

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import calendar
-import datetime
+import datetime as dt
 import re
 from dataclasses import dataclass
 from decimal import Decimal
@@ -77,7 +77,7 @@ class GS1ElementString:
     sscc_error: Optional[str] = None
 
     #: A date created from the element string, if the AI represents a date.
-    date: Optional[datetime.date] = None
+    date: Optional[dt.date] = None
 
     #: A decimal value created from the element string, if the AI represents a number.
     decimal: Optional[Decimal] = None
@@ -268,12 +268,12 @@ class GS1ElementString:
         return f"{self.ai}{self.value}"
 
 
-def _parse_date(value: str) -> datetime.date:
+def _parse_date(value: str) -> dt.date:
     year, month, day = int(value[0:2]), int(value[2:4]), int(value[4:6])
     year += _get_century(year)
     if day == 0:
         day = _get_last_day_of_month(year, month)
-    return datetime.date(year, month, day)
+    return dt.date(year, month, day)
 
 
 def _get_century(two_digit_year: int) -> int:
@@ -291,7 +291,7 @@ def _get_century(two_digit_year: int) -> int:
     References:
         GS1 General Specifications, section 7.12
     """
-    current_year = datetime.datetime.now(tz=datetime.timezone.utc).year
+    current_year = dt.datetime.now(tz=dt.timezone.utc).year
     current_century = current_year - current_year % 100
     two_digit_current_year = current_year - current_century
 

--- a/tests/gs1/test_element_strings.py
+++ b/tests/gs1/test_element_strings.py
@@ -1,5 +1,4 @@
-import datetime
-from datetime import date
+import datetime as dt
 from decimal import Decimal
 from typing import Optional
 
@@ -193,7 +192,7 @@ def test_extract_fails_with_invalid_date(ai_code: str, bad_value: str) -> None:
     )
 
 
-THIS_YEAR = datetime.datetime.now(tz=datetime.timezone.utc).year
+THIS_YEAR = dt.datetime.now(tz=dt.timezone.utc).year
 THIS_YEAR_SHORT = str(THIS_YEAR)[2:]
 MIN_YEAR = THIS_YEAR - 49
 MIN_YEAR_SHORT = str(MIN_YEAR)[2:]
@@ -211,7 +210,7 @@ MAX_YEAR_SHORT = str(MAX_YEAR)[2:]
                 ai=GS1ApplicationIdentifier.extract("15"),
                 value=f"{THIS_YEAR_SHORT}0526",
                 pattern_groups=[f"{THIS_YEAR_SHORT}0526"],
-                date=date(THIS_YEAR, 5, 26),
+                date=dt.date(THIS_YEAR, 5, 26),
             ),
         ),
         (
@@ -221,7 +220,7 @@ MAX_YEAR_SHORT = str(MAX_YEAR)[2:]
                 ai=GS1ApplicationIdentifier.extract("15"),
                 value=f"{MIN_YEAR_SHORT}0526",
                 pattern_groups=[f"{MIN_YEAR_SHORT}0526"],
-                date=date(MIN_YEAR, 5, 26),
+                date=dt.date(MIN_YEAR, 5, 26),
             ),
         ),
         (
@@ -231,7 +230,7 @@ MAX_YEAR_SHORT = str(MAX_YEAR)[2:]
                 ai=GS1ApplicationIdentifier.extract("15"),
                 value=f"{MAX_YEAR_SHORT}0526",
                 pattern_groups=[f"{MAX_YEAR_SHORT}0526"],
-                date=date(MAX_YEAR, 5, 26),
+                date=dt.date(MAX_YEAR, 5, 26),
             ),
         ),
     ],
@@ -245,13 +244,13 @@ def test_extract_handles_min_and_max_year_correctly(
 @pytest.mark.parametrize(
     ("value", "expected"),
     [
-        ("15200200", date(2020, 2, 29)),
-        ("15210200", date(2021, 2, 28)),
-        ("17211200", date(2021, 12, 31)),
+        ("15200200", dt.date(2020, 2, 29)),
+        ("15210200", dt.date(2021, 2, 28)),
+        ("17211200", dt.date(2021, 12, 31)),
     ],
 )
 def test_extract_handles_zero_day_as_last_day_of_month(
-    value: str, expected: date
+    value: str, expected: dt.date
 ) -> None:
     assert GS1ElementString.extract(value).date == expected
 

--- a/tests/gs1/test_element_strings.py
+++ b/tests/gs1/test_element_strings.py
@@ -80,6 +80,8 @@ from biip.sscc import Sscc
                 ai=GS1ApplicationIdentifier.extract("7011"),
                 value="030102",
                 pattern_groups=["030102"],
+                date=dt.date(2003, 1, 2),
+                datetime=None,
             ),
         ),
         (
@@ -88,6 +90,8 @@ from biip.sscc import Sscc
                 ai=GS1ApplicationIdentifier.extract("7011"),
                 value="0301021430",
                 pattern_groups=["030102", "1430"],
+                date=dt.date(2003, 1, 2),
+                datetime=dt.datetime(2003, 1, 2, 14, 30),  # noqa: DTZ001
             ),
         ),
         (
@@ -173,6 +177,39 @@ def test_extract_fails_when_not_matching_pattern(ai_code: str, bad_value: str) -
 
 
 @pytest.mark.parametrize(
+    ("value", "expected_date", "expected_datetime"),
+    [
+        ("11030201", dt.date(2003, 2, 1), None),
+        ("12030201", dt.date(2003, 2, 1), None),
+        ("13030201", dt.date(2003, 2, 1), None),
+        ("15030201", dt.date(2003, 2, 1), None),
+        ("16030201", dt.date(2003, 2, 1), None),
+        ("17030201", dt.date(2003, 2, 1), None),
+        ("43240701029999", dt.date(2007, 1, 2), None),
+        ("43240701021430", dt.date(2007, 1, 2), dt.datetime(2007, 1, 2, 14, 30)),  # noqa: DTZ001
+        ("43250701029999", dt.date(2007, 1, 2), None),
+        ("43250701021430", dt.date(2007, 1, 2), dt.datetime(2007, 1, 2, 14, 30)),  # noqa: DTZ001
+        ("4326070102", dt.date(2007, 1, 2), None),
+        ("70030701021415", dt.date(2007, 1, 2), dt.datetime(2007, 1, 2, 14, 15)),  # noqa: DTZ001
+        ("7006030102", dt.date(2003, 1, 2), None),
+        ("7007030102", dt.date(2003, 1, 2), None),
+        ("7011030102", dt.date(2003, 1, 2), None),
+        ("70110301021430", dt.date(2003, 1, 2), dt.datetime(2003, 1, 2, 14, 30)),  # noqa: DTZ001
+        ("800800010214", dt.date(2000, 1, 2), dt.datetime(2000, 1, 2, 14, 0)),  # noqa: DTZ001
+        ("80080001021415", dt.date(2000, 1, 2), dt.datetime(2000, 1, 2, 14, 15)),  # noqa: DTZ001
+        ("8008000102141516", dt.date(2000, 1, 2), dt.datetime(2000, 1, 2, 14, 15, 16)),  # noqa: DTZ001
+    ],
+)
+def test_extract_date_and_datetime(
+    value: str, expected_date: dt.date, expected_datetime: Optional[dt.datetime]
+) -> None:
+    element_string = GS1ElementString.extract(value)
+
+    assert element_string.date == expected_date
+    assert element_string.datetime == expected_datetime
+
+
+@pytest.mark.parametrize(
     ("ai_code", "bad_value"),
     [
         # Bad production date
@@ -188,7 +225,8 @@ def test_extract_fails_with_invalid_date(ai_code: str, bad_value: str) -> None:
         GS1ElementString.extract(f"{ai_code}{bad_value}")
 
     assert (
-        str(exc_info.value) == f"Failed to parse GS1 AI {ai} date from {bad_value!r}."
+        str(exc_info.value)
+        == f"Failed to parse GS1 AI {ai} date/time from {bad_value!r}."
     )
 
 

--- a/tests/gs1/test_messages.py
+++ b/tests/gs1/test_messages.py
@@ -140,7 +140,7 @@ def test_parse_with_too_long_separator_char_fails() -> None:
             "Failed to get GS1 Application Identifier from 'aaa'.",
         ),
         # Too short to match optional time group (as this is really a GTIN-13)
-        ("701197206489", "Failed to get GS1 Application Identifier from '89'."),
+        ("701103020185", "Failed to get GS1 Application Identifier from '85'."),
     ],
 )
 def test_parse_fails_if_unparsed_data_left(value: str, error: str) -> None:

--- a/tests/gs1/test_messages.py
+++ b/tests/gs1/test_messages.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 from decimal import Decimal
 from typing import Iterable, List, Optional
 
@@ -41,7 +41,7 @@ from biip.gtin import Gtin, GtinFormat, Rcn, RcnRegion
                         ai=GS1ApplicationIdentifier.extract("15"),
                         value="210526",
                         pattern_groups=["210526"],
-                        date=date(2021, 5, 26),
+                        date=dt.date(2021, 5, 26),
                     ),
                     GS1ElementString(
                         ai=GS1ApplicationIdentifier.extract("10"),
@@ -184,7 +184,7 @@ def test_parse_strips_surrounding_whitespace() -> None:
                         ai=GS1ApplicationIdentifier.extract("17"),
                         value="221231",
                         pattern_groups=["221231"],
-                        date=date(2022, 12, 31),
+                        date=dt.date(2022, 12, 31),
                     )
                 ],
             ),
@@ -203,7 +203,7 @@ def test_parse_strips_surrounding_whitespace() -> None:
                         ai=GS1ApplicationIdentifier.extract("17"),
                         value="221231",
                         pattern_groups=["221231"],
-                        date=date(2022, 12, 31),
+                        date=dt.date(2022, 12, 31),
                     ),
                 ],
             ),
@@ -217,7 +217,7 @@ def test_parse_strips_surrounding_whitespace() -> None:
                         ai=GS1ApplicationIdentifier.extract("17"),
                         value="221231",
                         pattern_groups=["221231"],
-                        date=date(2022, 12, 31),
+                        date=dt.date(2022, 12, 31),
                     ),
                     GS1ElementString(
                         ai=GS1ApplicationIdentifier.extract("10"),

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -1,4 +1,4 @@
-from datetime import date
+import datetime as dt
 from decimal import Decimal
 
 import pytest
@@ -539,7 +539,7 @@ from biip.upc import Upc, UpcFormat
                             ai=GS1ApplicationIdentifier.extract("15"),
                             value="210527",
                             pattern_groups=["210527"],
-                            date=date(2021, 5, 27),
+                            date=dt.date(2021, 5, 27),
                         )
                     ],
                 ),
@@ -584,7 +584,7 @@ from biip.upc import Upc, UpcFormat
                             ai=GS1ApplicationIdentifier.extract("15"),
                             value="210526",
                             pattern_groups=["210526"],
-                            date=date(2021, 5, 26),
+                            date=dt.date(2021, 5, 26),
                         ),
                     ],
                 ),


### PR DESCRIPTION
Extracting dates from AI 11/12/13/15/16/17 is already supported.

This adds support for extracting dates and potentially datetimes from AI
4324/4325/4326/7003/7006/7007/7011/8008.
