### PR TITLE
Fix resource file access to support zipped package environments

### DIFF
--- a/src/biip/gs1/_application_identifiers.py
+++ b/src/biip/gs1/_application_identifiers.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-import pathlib
 from dataclasses import dataclass, field
+from importlib import resources
 
 from biip import ParseError
 
@@ -89,14 +89,12 @@ class GS1ApplicationIdentifier:
         return f"({self.ai})"
 
 
-_GS1_APPLICATION_IDENTIFIERS_FILE = (
-    pathlib.Path(__file__).parent / "_application_identifiers.json"
-)
+def _load_application_identifiers():
+    with resources.open_text(__package__, '_application_identifiers.json') as f:
+        data = json.load(f)
+    return {
+        entry['ai']: GS1ApplicationIdentifier(**entry)
+        for entry in data
+    }
 
-_GS1_APPLICATION_IDENTIFIERS = {
-    entry.ai: entry
-    for entry in [
-        GS1ApplicationIdentifier(**kwargs)
-        for kwargs in json.loads(_GS1_APPLICATION_IDENTIFIERS_FILE.read_text())
-    ]
-}
+_GS1_APPLICATION_IDENTIFIERS = _load_application_identifiers()


### PR DESCRIPTION
## Description

This PR addresses an issue where the `biip` package fails to access resource files when deployed in environments where the package is zipped, such as in Snowflake UDFs or other systems that package Python modules into zip files. The error encountered is:

```
NotADirectoryError: [Errno 20] Not a directory: '/path/to/biip.zip/biip/gs1/_application_identifiers.json'
```

## Problem

The current implementation uses `pathlib` and `__file__` to construct a file path to `_application_identifiers.json`:

```python
_GS1_APPLICATION_IDENTIFIERS_FILE = (
    pathlib.Path(__file__).parent / "_application_identifiers.json"
)
```

This approach assumes that the package files are accessible via the file system, which is not the case when the package is zipped. In such cases, attempting to access files using file paths results in a `NotADirectoryError`.

## Solution

Modify the code to use `importlib.resources` for accessing the resource file. This module is designed for reading resources bundled within Python packages, regardless of whether they are stored in the file system or in a zip archive.

**Changes:**

- Replace the use of `pathlib` and `__file__` with `importlib.resources`.
- Update the code to load the JSON file using `importlib.resources.open_text()`.

## Benefits

- **Compatibility**: Ensures that `biip` works correctly in environments where packages are zipped.

- **Portability**: Aligns with Python's recommended practices for resource file access.

- **No External Dependencies**: Uses the standard library available in Python 3.7 and above.

## Reference Documentation

- [Python Documentation - `importlib.resources`](https://docs.python.org/3/library/importlib.resources.html)

  > The `importlib.resources` module provides an API for accessing resources embedded within packages, whether or not the package is a traditional file system package or a zip file.

- [PEP 273 – Import Modules from Zip Archives](https://peps.python.org/pep-0273/)

  > Describes how Python can import modules from zip archives, and the implications for accessing resources within those modules.

## Conclusion

This change enhances the portability and robustness of the `biip` package by ensuring it can access its resource files regardless of the packaging format. It aligns with best practices for resource management in Python packages and resolves issues encountered in zipped package environments.
