### PR TITLE
Use `importlib.resources` to load data files

### DIFF
--- a/src/biip/gs1/_application_identifiers.py
+++ b/src/biip/gs1/_application_identifiers.py
@@ -3,8 +3,8 @@
 from __future__ import annotations
 
 import json
-import pathlib
 from dataclasses import dataclass, field
+from importlib import resources
 
 from biip import ParseError
 
@@ -89,14 +89,12 @@ class GS1ApplicationIdentifier:
         return f"({self.ai})"
 
 
-_GS1_APPLICATION_IDENTIFIERS_FILE = (
-    pathlib.Path(__file__).parent / "_application_identifiers.json"
-)
+def _load_application_identifiers():
+    with resources.open_text(__package__, '_application_identifiers.json') as f:
+        data = json.load(f)
+    return {
+        entry['ai']: GS1ApplicationIdentifier(**entry)
+        for entry in data
+    }
 
-_GS1_APPLICATION_IDENTIFIERS = {
-    entry.ai: entry
-    for entry in [
-        GS1ApplicationIdentifier(**kwargs)
-        for kwargs in json.loads(_GS1_APPLICATION_IDENTIFIERS_FILE.read_text())
-    ]
-}
+_GS1_APPLICATION_IDENTIFIERS = _load_application_identifiers()

--- a/src/biip/gs1/_application_identifiers.py
+++ b/src/biip/gs1/_application_identifiers.py
@@ -89,12 +89,13 @@ class GS1ApplicationIdentifier:
         return f"({self.ai})"
 
 
-def _load_application_identifiers():
-    with resources.open_text(__package__, '_application_identifiers.json') as f:
-        data = json.load(f)
-    return {
-        entry['ai']: GS1ApplicationIdentifier(**entry)
-        for entry in data
-    }
-
-_GS1_APPLICATION_IDENTIFIERS = _load_application_identifiers()
+_GS1_APPLICATION_IDENTIFIERS_FILE = (
+    resources.files("biip") / "gs1" / "_application_identifiers.json"
+)
+_GS1_APPLICATION_IDENTIFIERS = {
+    entry.ai: entry
+    for entry in [
+        GS1ApplicationIdentifier(**kwargs)
+        for kwargs in json.loads(_GS1_APPLICATION_IDENTIFIERS_FILE.read_text())
+    ]
+}

--- a/src/biip/gs1/_prefixes.py
+++ b/src/biip/gs1/_prefixes.py
@@ -142,22 +142,15 @@ class _GS1PrefixRange:
     usage: str
 
 
-def _load_prefix_ranges():
-    with resources.open_text(__package__, "_prefix_ranges.json") as f:
-        data = json.load(f)
-    return [_GS1PrefixRange(**kwargs) for kwargs in data]
+_GS1_PREFIX_RANGES_FILE = resources.files("biip") / "gs1" / "_prefix_ranges.json"
+_GS1_PREFIX_RANGES = [
+    _GS1PrefixRange(**kwargs)
+    for kwargs in json.loads(_GS1_PREFIX_RANGES_FILE.read_text())
+]
 
-
-_GS1_PREFIX_RANGES = _load_prefix_ranges()
-
-
-def _load_company_prefix_trie():
-    with resources.open_binary(
-        __package__, "_company_prefix_trie.json.lzma"
-    ) as compressed_file:
-        decompressed_data = lzma.decompress(compressed_file.read())
-        data = json.loads(decompressed_data.decode("utf-8"))
-    return data
-
-
-_GS1_COMPANY_PREFIX_TRIE: _TrieNode = _load_company_prefix_trie()
+_GS1_COMPANY_PREFIX_TRIE_FILE = (
+    resources.files("biip") / "gs1" / "_company_prefix_trie.json.lzma"
+)
+_GS1_COMPANY_PREFIX_TRIE: _TrieNode = json.loads(
+    lzma.decompress(_GS1_COMPANY_PREFIX_TRIE_FILE.read_bytes()).decode()
+)

--- a/src/biip/gs1/_prefixes.py
+++ b/src/biip/gs1/_prefixes.py
@@ -12,8 +12,8 @@ from __future__ import annotations
 
 import json
 import lzma
-import pathlib
 from dataclasses import dataclass
+from importlib import resources
 from typing import Optional, Union
 
 from biip import ParseError
@@ -142,16 +142,22 @@ class _GS1PrefixRange:
     usage: str
 
 
-_GS1_PREFIX_RANGES_FILE = pathlib.Path(__file__).parent / "_prefix_ranges.json"
+def _load_prefix_ranges():
+    with resources.open_text(__package__, "_prefix_ranges.json") as f:
+        data = json.load(f)
+    return [_GS1PrefixRange(**kwargs) for kwargs in data]
 
-_GS1_PREFIX_RANGES = [
-    _GS1PrefixRange(**kwargs)
-    for kwargs in json.loads(_GS1_PREFIX_RANGES_FILE.read_text())
-]
 
-_GS1_COMPANY_PREFIX_TRIE_FILE = (
-    pathlib.Path(__file__).parent / "_company_prefix_trie.json.lzma"
-)
+_GS1_PREFIX_RANGES = _load_prefix_ranges()
 
-with lzma.open(_GS1_COMPANY_PREFIX_TRIE_FILE) as fh:
-    _GS1_COMPANY_PREFIX_TRIE: _TrieNode = json.load(fh)
+
+def _load_company_prefix_trie():
+    with resources.open_binary(
+        __package__, "_company_prefix_trie.json.lzma"
+    ) as compressed_file:
+        decompressed_data = lzma.decompress(compressed_file.read())
+        data = json.loads(decompressed_data.decode("utf-8"))
+    return data
+
+
+_GS1_COMPANY_PREFIX_TRIE: _TrieNode = _load_company_prefix_trie()


### PR DESCRIPTION
To support loading data sets when the library is installed as a zipped package.

Based upon PR #324, but using newer APIs available since Python 3.9, which we require as of #326.

Fixes #324
