### PR TITLE
Support pretty-printed output in doctests

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,22 @@
+"""Test setup for doctests."""
+
+# For the fixture to be available when running doctests, this file must be placed
+# in the `src/` tree or outside of it, not in the `tests/` tree.
+
+from typing import Any
+
+import pytest
+from rich.pretty import pprint
+
+
+def doctest_print(*args: Any) -> None:  # noqa: ANN401, D103
+    return pprint(
+        *args,
+        expand_all=True,
+        indent_guides=False,
+    )
+
+
+@pytest.fixture(autouse=True, scope="session")
+def pprint_setup(doctest_namespace: dict[str, Any]) -> None:  # noqa: D103
+    doctest_namespace["pprint"] = doctest_print

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ tests = [
     "coverage>=7.6.12",
     "pytest>=8.3.4",
     "pytest-cov>=6.0.0",
-    "xdoctest>=1.2.0",
+    "rich>=13.9.4",
 ]
 
 
@@ -75,7 +75,8 @@ show_missing = true
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--xdoc"
+addopts = "--doctest-modules"
+doctest_optionflags = ["NORMALIZE_WHITESPACE"]
 filterwarnings = ["ignore:pygments is not installed.*:UserWarning"]
 
 
@@ -173,6 +174,8 @@ commands = [
         "pytest",
         "--cov",
         "--basetemp={envtmpdir}",
+        "tests",                                # unit tests
+        "{envsitepackagesdir}/biip",            # doctests
         { replace = "posargs", extend = true },
     ],
 ]

--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -6,19 +6,50 @@ An ambiguous value may be interpreted as different formats. In the following
 example, the value can be interpreted as either a GTIN or a GS1 Message.
 
     >>> result = biip.parse("96385074")
-    >>> result.gtin
-    Gtin(value='96385074', format=GtinFormat.GTIN_8,
-    prefix=GS1Prefix(value='00009', usage='GS1 US'),
-    company_prefix=GS1CompanyPrefix(value='0000963'), payload='9638507',
-    check_digit=4, packaging_level=None)
-    >>> result.gs1_message
-    GS1Message(value='96385074',
-    element_strings=[GS1ElementString(ai=GS1ApplicationIdentifier(ai='96',
-    description='Company internal information', data_title='INTERNAL',
-    fnc1_required=True, format='N2+X..90'), value='385074',
-    pattern_groups=['385074'], gln=None, gln_error=None, gtin=None,
-    gtin_error=None, sscc=None, sscc_error=None, date=None, datetime=None,
-    decimal=None, money=None)])
+    >>> pprint(result.gtin)
+    Gtin(
+        value='96385074',
+        format=GtinFormat.GTIN_8,
+        prefix=GS1Prefix(
+            value='00009',
+            usage='GS1 US'
+        ),
+        company_prefix=GS1CompanyPrefix(
+            value='0000963'
+        ),
+        payload='9638507',
+        check_digit=4,
+        packaging_level=None
+    )
+    >>> pprint(result.gs1_message)
+    GS1Message(
+        value='96385074',
+        element_strings=[
+            GS1ElementString(
+                ai=GS1ApplicationIdentifier(
+                    ai='96',
+                    description='Company internal information',
+                    data_title='INTERNAL',
+                    fnc1_required=True,
+                    format='N2+X..90'
+                ),
+                value='385074',
+                pattern_groups=[
+                    '385074'
+                ],
+                gln=None,
+                gln_error=None,
+                gtin=None,
+                gtin_error=None,
+                sscc=None,
+                sscc_error=None,
+                date=None,
+                datetime=None,
+                decimal=None,
+                money=None
+            )
+        ]
+    )
 
 In the next example, the value is only valid as a GS1 Message and the GTIN
 parser returns an error explaining why the value cannot be interpreted as a
@@ -26,18 +57,39 @@ GTIN. If a format includes check digits, Biip always control them and fail if
 the check digits are incorrect.
 
     >>> result = biip.parse("15210527")
-    >>> result.gtin
+    >>> print(result.gtin)
     None
     >>> result.gtin_error
     "Invalid GTIN check digit for '15210527': Expected 4, got 7."
-    >>> result.gs1_message
-    GS1Message(value='15210527',
-    element_strings=[GS1ElementString(ai=GS1ApplicationIdentifier(ai='15',
-    description='Best before date (YYMMDD)', data_title='BEST BEFORE or BEST
-    BY', fnc1_required=False, format='N2+N6'), value='210527',
-    pattern_groups=['210527'], gln=None, gln_error=None, gtin=None,
-    gtin_error=None, sscc=None, sscc_error=None, date=datetime.date(2021, 5,
-    27), datetime=None, decimal=None, money=None)])
+    >>> pprint(result.gs1_message)
+    GS1Message(
+        value='15210527',
+        element_strings=[
+            GS1ElementString(
+                ai=GS1ApplicationIdentifier(
+                    ai='15',
+                    description='Best before date (YYMMDD)',
+                    data_title='BEST BEFORE or BEST BY',
+                    fnc1_required=False,
+                    format='N2+N6'
+                ),
+                value='210527',
+                pattern_groups=[
+                    '210527'
+                ],
+                gln=None,
+                gln_error=None,
+                gtin=None,
+                gtin_error=None,
+                sscc=None,
+                sscc_error=None,
+                date=datetime.date(2021, 5, 27),
+                datetime=None,
+                decimal=None,
+                money=None
+            )
+        ]
+    )
 
 If a value cannot be interpreted as any supported format, an exception is
 raised with a reason from each parser.

--- a/src/biip/gln.py
+++ b/src/biip/gln.py
@@ -10,10 +10,19 @@ If you only want to parse GLNs, you can import the GLN parser directly.
 If parsing succeeds, it returns a `Gln` object.
 
     >>> gln = Gln.parse("1234567890128")
-    >>> gln
-    Gln(value='1234567890128', prefix=GS1Prefix(value='123',
-    usage='GS1 US'), company_prefix=GS1CompanyPrefix(value='1234567890'),
-    payload='123456789012', check_digit=8)
+    >>> pprint(gln)
+    Gln(
+        value='1234567890128',
+        prefix=GS1Prefix(
+            value='123',
+            usage='GS1 US'
+        ),
+        company_prefix=GS1CompanyPrefix(
+            value='1234567890'
+        ),
+        payload='123456789012',
+        check_digit=8
+    )
 
 As GLNs do not appear independently in barcodes, the GLN parser is not a part of
 the top-level parser `biip.parse()`. However, if you are parsing a barcode with
@@ -21,10 +30,24 @@ GS1 element strings including a GLN, the GLN will be parsed and validated using
 the `Gln` class.
 
     >>> import biip
-    >>> biip.parse("4101234567890128").gs1_message.get(data_title="SHIP TO").gln
-    Gln(value='1234567890128', prefix=GS1Prefix(value='123', usage='GS1 US'),
-    company_prefix=GS1CompanyPrefix(value='1234567890'), payload='123456789012',
-    check_digit=8)
+    >>> gln = (
+    ...     biip.parse("4101234567890128")
+    ...     .gs1_message.get(data_title="SHIP TO")
+    ...     .gln
+    ... )
+    >>> pprint(gln)
+    Gln(
+        value='1234567890128',
+        prefix=GS1Prefix(
+            value='123',
+            usage='GS1 US'
+        ),
+        company_prefix=GS1CompanyPrefix(
+            value='1234567890'
+        ),
+        payload='123456789012',
+        check_digit=8
+    )
 """
 
 from __future__ import annotations

--- a/src/biip/gs1/__init__.py
+++ b/src/biip/gs1/__init__.py
@@ -31,7 +31,7 @@ barcode.
 
 HRI can also be parsed.
 
-    >>> GS1Message.parse_hri("(01)07032069804988(15)210526(10)0329")
+    >>> msg = GS1Message.parse_hri("(01)07032069804988(15)210526(10)0329")
 
 A message can contain multiple element strings.
 
@@ -40,34 +40,96 @@ A message can contain multiple element strings.
 
 In this example, the first element string is a GTIN.
 
-    >>> msg.element_strings[0]
-    GS1ElementString(ai=GS1ApplicationIdentifier(ai='01', description='Global
-    Trade Item Number (GTIN)', data_title='GTIN', fnc1_required=False,
-    format='N2+N14'), value='07032069804988', pattern_groups=['07032069804988'],
-    gln=None, gln_error=None, gtin=Gtin(value='07032069804988',
-    format=GtinFormat.GTIN_13, prefix=GS1Prefix(value='703', usage='GS1
-    Norway'), company_prefix=GS1CompanyPrefix(value='703206'),
-    payload='703206980498', check_digit=8, packaging_level=None),
-    gtin_error=None, sscc=None, sscc_error=None, date=None, datetime=None,
-    decimal=None, money=None)
+    >>> pprint(msg.element_strings[0])
+    GS1ElementString(
+        ai=GS1ApplicationIdentifier(
+            ai='01',
+            description='Global Trade Item Number (GTIN)',
+            data_title='GTIN',
+            fnc1_required=False,
+            format='N2+N14'
+        ),
+        value='07032069804988',
+        pattern_groups=[
+            '07032069804988'
+        ],
+        gln=None,
+        gln_error=None,
+        gtin=Gtin(
+            value='07032069804988',
+            format=GtinFormat.GTIN_13,
+            prefix=GS1Prefix(
+                value='703',
+                usage='GS1 Norway'
+            ),
+            company_prefix=GS1CompanyPrefix(
+                value='703206'
+            ),
+            payload='703206980498',
+            check_digit=8,
+            packaging_level=None
+        ),
+        gtin_error=None,
+        sscc=None,
+        sscc_error=None,
+        date=None,
+        datetime=None,
+        decimal=None,
+        money=None
+    )
 
 The message object has `GS1Message.get()` and `GS1Message.filter()`
 methods to lookup element strings either by the Application Identifier's
 "data title" or its AI number.
 
-    >>> msg.get(data_title='BEST BY')
-    GS1ElementString(ai=GS1ApplicationIdentifier(ai='15', description='Best
-    before date (YYMMDD)', data_title='BEST BEFORE or BEST BY',
-    fnc1_required=False, format='N2+N6'), value='210526',
-    pattern_groups=['210526'], gln=None, gln_error=None, gtin=None,
-    gtin_error=None, sscc=None, sscc_error=None, date=datetime.date(2021, 5,
-    26), datetime=None, decimal=None, money=None)
-    >>> msg.get(ai="10")
-    GS1ElementString(ai=GS1ApplicationIdentifier(ai='10', description='Batch
-    or lot number', data_title='BATCH/LOT', fnc1_required=True,
-    format='N2+X..20'), value='0329', pattern_groups=['0329'], gln=None,
-    gln_error=None, gtin=None, gtin_error=None, sscc=None, sscc_error=None,
-    date=None, datetime=None, decimal=None, money=None)
+    >>> pprint(msg.get(data_title='BEST BY'))
+    GS1ElementString(
+        ai=GS1ApplicationIdentifier(
+            ai='15',
+            description='Best before date (YYMMDD)',
+            data_title='BEST BEFORE or BEST BY',
+            fnc1_required=False,
+            format='N2+N6'
+        ),
+        value='210526',
+        pattern_groups=[
+            '210526'
+        ],
+        gln=None,
+        gln_error=None,
+        gtin=None,
+        gtin_error=None,
+        sscc=None,
+        sscc_error=None,
+        date=datetime.date(2021, 5, 26),
+        datetime=None,
+        decimal=None,
+        money=None
+    )
+    >>> pprint(msg.get(ai="10"))
+    GS1ElementString(
+        ai=GS1ApplicationIdentifier(
+            ai='10',
+            description='Batch or lot number',
+            data_title='BATCH/LOT',
+            fnc1_required=True,
+            format='N2+X..20'
+        ),
+        value='0329',
+        pattern_groups=[
+            '0329'
+        ],
+        gln=None,
+        gln_error=None,
+        gtin=None,
+        gtin_error=None,
+        sscc=None,
+        sscc_error=None,
+        date=None,
+        datetime=None,
+        decimal=None,
+        money=None
+    )
 """
 
 ASCII_GROUP_SEPARATOR = "\x1d"

--- a/src/biip/gs1/_application_identifiers.py
+++ b/src/biip/gs1/_application_identifiers.py
@@ -26,10 +26,14 @@ class GS1ApplicationIdentifier:
     Examples:
         >>> from biip.gs1 import GS1ApplicationIdentifier
         >>> ai = GS1ApplicationIdentifier.extract("01")
-        >>> ai
-        GS1ApplicationIdentifier(ai='01', description='Global Trade Item
-        Number (GTIN)', data_title='GTIN', fnc1_required=False,
-        format='N2+N14')
+        >>> pprint(ai)
+        GS1ApplicationIdentifier(
+            ai='01',
+            description='Global Trade Item Number (GTIN)',
+            data_title='GTIN',
+            fnc1_required=False,
+            format='N2+N14'
+        )
         >>> ai.pattern
         '^01(\\d{14})$'
     """
@@ -70,10 +74,15 @@ class GS1ApplicationIdentifier:
 
         Examples:
             >>> from biip.gs1 import GS1ApplicationIdentifier
-            >>> GS1ApplicationIdentifier.extract("010703206980498815210526100329")
-            GS1ApplicationIdentifier(ai='01', description='Global Trade Item
-            Number (GTIN)', data_title='GTIN', fnc1_required=False,
-            format='N2+N14')
+            >>> ai = GS1ApplicationIdentifier.extract("010703206980498815210526100329")
+            >>> pprint(ai)
+            GS1ApplicationIdentifier(
+                ai='01',
+                description='Global Trade Item Number (GTIN)',
+                data_title='GTIN',
+                fnc1_required=False,
+                format='N2+N14'
+            )
         """
         for application_identifier in _GS1_APPLICATION_IDENTIFIERS.values():
             if value.startswith(application_identifier.ai):

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -38,16 +38,43 @@ class GS1ElementString:
     Examples:
         >>> from biip.gs1 import GS1ElementString
         >>> element_string = GS1ElementString.extract("0107032069804988")
-        >>> element_string
-        GS1ElementString(ai=GS1ApplicationIdentifier(ai='01',
-        description='Global Trade Item Number (GTIN)', data_title='GTIN',
-        fnc1_required=False, format='N2+N14'), value='07032069804988',
-        pattern_groups=['07032069804988'], gln=None, gln_error=None,
-        gtin=Gtin(value='07032069804988', format=GtinFormat.GTIN_13,
-        prefix=GS1Prefix(value='703', usage='GS1 Norway'),
-        company_prefix=GS1CompanyPrefix(value='703206'), payload='703206980498',
-        check_digit=8, packaging_level=None), gtin_error=None, sscc=None,
-        sscc_error=None, date=None, datetime=None, decimal=None, money=None)
+        >>> pprint(element_string)
+        GS1ElementString(
+            ai=GS1ApplicationIdentifier(
+                ai='01',
+                description='Global Trade Item Number (GTIN)',
+                data_title='GTIN',
+                fnc1_required=False,
+                format='N2+N14'
+            ),
+            value='07032069804988',
+            pattern_groups=[
+                '07032069804988'
+            ],
+            gln=None,
+            gln_error=None,
+            gtin=Gtin(
+                value='07032069804988',
+                format=GtinFormat.GTIN_13,
+                prefix=GS1Prefix(
+                    value='703',
+                    usage='GS1 Norway'
+                ),
+                company_prefix=GS1CompanyPrefix(
+                    value='703206'
+                ),
+                payload='703206980498',
+                check_digit=8,
+                packaging_level=None
+            ),
+            gtin_error=None,
+            sscc=None,
+            sscc_error=None,
+            date=None,
+            datetime=None,
+            decimal=None,
+            money=None
+        )
         >>> element_string.as_hri()
         '(01)07032069804988'
     """

--- a/src/biip/gtin/__init__.py
+++ b/src/biip/gtin/__init__.py
@@ -19,11 +19,21 @@ instead of using `biip.parse()`.
 If parsing succeeds, it returns a `Gtin` object.
 
     >>> gtin = Gtin.parse("7032069804988")
-    >>> gtin
-    Gtin(value='7032069804988', format=GtinFormat.GTIN_13,
-    prefix=GS1Prefix(value='703', usage='GS1 Norway'),
-    company_prefix=GS1CompanyPrefix(value='703206'), payload='703206980498',
-    check_digit=8, packaging_level=None)
+    >>> pprint(gtin)
+    Gtin(
+        value='7032069804988',
+        format=GtinFormat.GTIN_13,
+        prefix=GS1Prefix(
+            value='703',
+            usage='GS1 Norway'
+        ),
+        company_prefix=GS1CompanyPrefix(
+            value='703206'
+        ),
+        payload='703206980498',
+        check_digit=8,
+        packaging_level=None
+    )
 
 A GTIN can be converted to any other GTIN format, as long as the target
 format is longer.

--- a/src/biip/sscc.py
+++ b/src/biip/sscc.py
@@ -11,10 +11,20 @@ instead of using `biip.parse()`.
 If parsing succeeds, it returns a `Sscc` object.
 
     >>> sscc = Sscc.parse("157035381410375177")
-    >>> sscc
-    Sscc(value='157035381410375177', prefix=GS1Prefix(value='570', usage='GS1
-    Denmark'), company_prefix=GS1CompanyPrefix(value='5703538'),
-    extension_digit=1, payload='15703538141037517', check_digit=7)
+    >>> pprint(sscc)
+    Sscc(
+        value='157035381410375177',
+        prefix=GS1Prefix(
+            value='570',
+            usage='GS1 Denmark'
+        ),
+        company_prefix=GS1CompanyPrefix(
+            value='5703538'
+        ),
+        extension_digit=1,
+        payload='15703538141037517',
+        check_digit=7
+    )
 
 Biip can format the SSCC in HRI format for printing on a label.
 

--- a/src/biip/symbology.py
+++ b/src/biip/symbology.py
@@ -11,12 +11,22 @@ characters.
 
 Examples:
     >>> from biip.symbology import SymbologyIdentifier
-    >>> SymbologyIdentifier.extract("]E05901234123457")
-    SymbologyIdentifier(value=']E0', symbology=Symbology.EAN_UPC,
-    modifiers='0', gs1_symbology=GS1Symbology.EAN_13)
-    >>> SymbologyIdentifier.extract("]I198765432109213")
-    SymbologyIdentifier(value=']I1', symbology=Symbology.ITF,
-    modifiers='1', gs1_symbology=GS1Symbology.ITF_14)
+    >>> si = SymbologyIdentifier.extract("]E05901234123457")
+    >>> pprint(si)
+    SymbologyIdentifier(
+        value=']E0',
+        symbology=Symbology.EAN_UPC,
+        modifiers='0',
+        gs1_symbology=GS1Symbology.EAN_13
+    )
+    >>> si = SymbologyIdentifier.extract("]I198765432109213")
+    >>> pprint(si)
+    SymbologyIdentifier(
+        value=']I1',
+        symbology=Symbology.ITF,
+        modifiers='1',
+        gs1_symbology=GS1Symbology.ITF_14
+    )
 
 References:
     ISO/IEC 15424:2008.


### PR DESCRIPTION
Replace xdoctest with plain pytest and rich to get to a setup where the pretty-printed output is validated.