### PR TITLE
Rename checksum functions

### DIFF
--- a/docs/api/checksums.md
+++ b/docs/api/checksums.md
@@ -1,0 +1,3 @@
+# `biip.checksums` - Checksums
+
+::: biip.checksums

--- a/docs/api/gs1-checksums.md
+++ b/docs/api/gs1-checksums.md
@@ -1,3 +1,0 @@
-# `biip.gs1.checksums` - GS1 checksums
-
-::: biip.gs1.checksums

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,9 +12,9 @@ nav:
   - quickstart.md
   - Reference:
       - api/biip.md
+      - api/checksums.md
       - api/gln.md
       - api/gs1.md
-      - api/gs1-checksums.md
       - api/gtin.md
       - api/sscc.md
       - api/symbology.md

--- a/src/biip/checksums.py
+++ b/src/biip/checksums.py
@@ -3,7 +3,7 @@
 import itertools
 
 
-def numeric_check_digit(value: str) -> int:
+def gs1_standard_check_digit(value: str) -> int:
     """Get GS1 check digit for numeric string.
 
     Args:
@@ -16,13 +16,13 @@ def numeric_check_digit(value: str) -> int:
         ValueError: If the value isn't numeric.
 
     References:
-        GS1 General Specification, section 7.9
+        GS1 General Specification, section 7.9.1
 
     Examples:
-        >>> from biip.gs1.checksums import numeric_check_digit
-        >>> numeric_check_digit("950110153100")  # GTIN-13
+        >>> from biip.checksums import gs1_standard_check_digit
+        >>> gs1_standard_check_digit("950110153100")  # GTIN-13
         0
-        >>> numeric_check_digit("9501234")  # GTIN-8
+        >>> gs1_standard_check_digit("9501234")  # GTIN-8
         6
     """
     if not value.isdecimal():
@@ -39,7 +39,7 @@ def numeric_check_digit(value: str) -> int:
     return (10 - weighted_sum % 10) % 10
 
 
-def price_check_digit(value: str) -> int:
+def gs1_price_weight_check_digit(value: str) -> int:
     """Get GS1 check digit for a price or weight field.
 
     Args:
@@ -55,10 +55,10 @@ def price_check_digit(value: str) -> int:
         GS1 General Specification, section 7.9.2-7.9.4
 
     Examples:
-        >>> from biip.gs1.checksums import price_check_digit
-        >>> price_check_digit("2875")
+        >>> from biip.checksums import gs1_price_weight_check_digit
+        >>> gs1_price_weight_check_digit("2875")
         9
-        >>> price_check_digit("14685")
+        >>> gs1_price_weight_check_digit("14685")
         6
     """
     if not value.isdecimal():
@@ -66,16 +66,16 @@ def price_check_digit(value: str) -> int:
         raise ValueError(msg)
 
     if len(value) == 4:
-        return _four_digit_price_check_digit(value)
+        return _four_digit_price_weight_check_digit(value)
 
     if len(value) == 5:
-        return _five_digit_price_check_digit(value)
+        return _five_digit_price_weight_check_digit(value)
 
     msg = f"Expected input of length 4 or 5, got {value!r}."
     raise ValueError(msg)
 
 
-def _four_digit_price_check_digit(value: str) -> int:
+def _four_digit_price_weight_check_digit(value: str) -> int:
     digits = list(map(int, list(value)))
     weight_sum = 0
     for digit, weight_map in zip(digits, _FOUR_DIGIT_POSITION_WEIGHTS):
@@ -84,7 +84,7 @@ def _four_digit_price_check_digit(value: str) -> int:
     return (weight_sum * 3) % 10
 
 
-def _five_digit_price_check_digit(value: str) -> int:
+def _five_digit_price_weight_check_digit(value: str) -> int:
     digits = list(map(int, list(value)))
     weighted_sum = 0
     for digit, weight_map in zip(digits, _FIVE_DIGIT_POSITION_WEIGHTS):

--- a/src/biip/gln.py
+++ b/src/biip/gln.py
@@ -56,8 +56,8 @@ from dataclasses import dataclass
 from typing import Optional
 
 from biip import ParseError
+from biip.checksums import gs1_standard_check_digit
 from biip.gs1 import GS1CompanyPrefix, GS1Prefix
-from biip.gs1.checksums import numeric_check_digit
 
 
 @dataclass
@@ -121,7 +121,7 @@ class Gln:
         payload = value[:-1]
         check_digit = int(value[-1])
 
-        calculated_check_digit = numeric_check_digit(payload)
+        calculated_check_digit = gs1_standard_check_digit(payload)
         if check_digit != calculated_check_digit:
             msg = (
                 f"Invalid GLN check digit for {value!r}: "

--- a/src/biip/gtin/_gtin.py
+++ b/src/biip/gtin/_gtin.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from typing import Optional, Union
 
 from biip import EncodeError, ParseError
+from biip.checksums import gs1_standard_check_digit
 from biip.gs1 import GS1CompanyPrefix, GS1Prefix
-from biip.gs1.checksums import numeric_check_digit
 from biip.gtin import GtinFormat, RcnRegion
 
 
@@ -125,7 +125,7 @@ class Gtin:
         prefix = GS1Prefix.extract(prefix_value)
         company_prefix = GS1CompanyPrefix.extract(prefix_value)
 
-        calculated_check_digit = numeric_check_digit(payload)
+        calculated_check_digit = gs1_standard_check_digit(payload)
         if check_digit != calculated_check_digit:
             msg = (
                 f"Invalid GTIN check digit for {value!r}: "

--- a/src/biip/gtin/_rcn.py
+++ b/src/biip/gtin/_rcn.py
@@ -8,7 +8,7 @@ from enum import Enum
 from typing import Optional, Union
 
 from biip import EncodeError, ParseError
-from biip.gs1 import checksums
+from biip.checksums import gs1_price_weight_check_digit, gs1_standard_check_digit
 from biip.gtin import Gtin, RcnRegion, RcnUsage
 
 try:
@@ -211,7 +211,7 @@ class _Strategy:
         rcn_13 = rcn.as_gtin_13()
         value = rcn_13[self.value_slice]
         check_digit = int(rcn_13[self.check_digit_slice])
-        calculated_check_digit = checksums.price_check_digit(value)
+        calculated_check_digit = gs1_price_weight_check_digit(value)
 
         if check_digit != calculated_check_digit:
             msg = (
@@ -238,11 +238,11 @@ class _Strategy:
         digits[self.value_slice] = list(zeroed_value)
         if self.check_digit_slice is not None:
             digits[self.check_digit_slice] = [
-                str(checksums.price_check_digit(zeroed_value))
+                str(gs1_price_weight_check_digit(zeroed_value))
             ]
 
         gtin_payload = "".join(digits)
-        gtin_check_digit = checksums.numeric_check_digit(gtin_payload)
+        gtin_check_digit = gs1_standard_check_digit(gtin_payload)
         gtin = f"{gtin_payload}{gtin_check_digit}"
         return Gtin.parse(gtin, rcn_region=rcn.region)
 

--- a/src/biip/sscc.py
+++ b/src/biip/sscc.py
@@ -43,8 +43,8 @@ from dataclasses import dataclass
 from typing import Optional
 
 from biip import ParseError
+from biip.checksums import gs1_standard_check_digit
 from biip.gs1 import GS1CompanyPrefix, GS1Prefix
-from biip.gs1.checksums import numeric_check_digit
 
 
 @dataclass
@@ -113,7 +113,7 @@ class Sscc:
         payload = value[:-1]
         check_digit = int(value[-1])
 
-        calculated_check_digit = numeric_check_digit(payload)
+        calculated_check_digit = gs1_standard_check_digit(payload)
         if check_digit != calculated_check_digit:
             msg = (
                 f"Invalid SSCC check digit for {value!r}: "

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -65,7 +65,7 @@ from enum import Enum
 from typing import Optional
 
 from biip import EncodeError, ParseError
-from biip.gs1.checksums import numeric_check_digit
+from biip.checksums import gs1_standard_check_digit
 
 
 class UpcFormat(Enum):
@@ -153,7 +153,7 @@ class Upc:
         number_system_digit = int(value[0])
         check_digit = int(value[-1])
 
-        calculated_check_digit = numeric_check_digit(payload)
+        calculated_check_digit = gs1_standard_check_digit(payload)
         if check_digit != calculated_check_digit:
             msg = (
                 f"Invalid UPC-A check digit for {value!r}: "
@@ -179,13 +179,13 @@ class Upc:
             number_system_digit = 0
             payload = f"{number_system_digit}{value}"
             upc_a_payload = _upc_e_to_upc_a_expansion(f"{payload}0")[:-1]
-            check_digit = numeric_check_digit(upc_a_payload)
+            check_digit = gs1_standard_check_digit(upc_a_payload)
         elif length == 7:
             # Explicit number system, no check digit.
             number_system_digit = int(value[0])
             payload = value
             upc_a_payload = _upc_e_to_upc_a_expansion(f"{payload}0")[:-1]
-            check_digit = numeric_check_digit(upc_a_payload)
+            check_digit = gs1_standard_check_digit(upc_a_payload)
         elif length == 8:
             # Explicit number system and check digit.
             number_system_digit = int(value[0])
@@ -205,7 +205,7 @@ class Upc:
 
         # Control that check digit is correct.
         upc_a_payload = _upc_e_to_upc_a_expansion(f"{payload}{check_digit}")[:-1]
-        calculated_check_digit = numeric_check_digit(upc_a_payload)
+        calculated_check_digit = gs1_standard_check_digit(upc_a_payload)
         if check_digit != calculated_check_digit:
             msg = (
                 f"Invalid UPC-E check digit for {value!r}: "

--- a/tests/gtin/test_without_variable_measure.py
+++ b/tests/gtin/test_without_variable_measure.py
@@ -1,7 +1,7 @@
 import pytest
 
 from biip import EncodeError
-from biip.gs1.checksums import numeric_check_digit
+from biip.checksums import gs1_standard_check_digit
 from biip.gtin import Gtin, Rcn, RcnRegion
 
 
@@ -80,7 +80,7 @@ def test_without_variable_measure_keeps_nonvariable_rcn_unchanged(
 ) -> None:
     for prefix in nonvariable_prefixes:
         payload = f"{prefix}1111111111"
-        value = f"{payload}{numeric_check_digit(payload)}"
+        value = f"{payload}{gs1_standard_check_digit(payload)}"
         original_rcn = Gtin.parse(value, rcn_region=rcn_region)
         assert isinstance(original_rcn, Rcn)
 

--- a/tests/test_checksums.py
+++ b/tests/test_checksums.py
@@ -1,15 +1,15 @@
 import pytest
 
-from biip.gs1.checksums import numeric_check_digit, price_check_digit
+from biip.checksums import gs1_price_weight_check_digit, gs1_standard_check_digit
 
 
 @pytest.mark.parametrize("value", ["abc", "⁰⁰⁰"])
-def test_numeric_check_digit_with_nonnumeric_value(value: str) -> None:
+def test_gs1_standard_check_digit_with_nonnumeric_value(value: str) -> None:
     with pytest.raises(
         ValueError,
         match=rf"^Expected numeric value, got {value!r}.$",
     ):
-        numeric_check_digit(value)
+        gs1_standard_check_digit(value)
 
 
 @pytest.mark.parametrize(
@@ -27,17 +27,17 @@ def test_numeric_check_digit_with_nonnumeric_value(value: str) -> None:
         ("708000382434", 9),
     ],
 )
-def test_numeric_check_digit(value: str, expected: int) -> None:
-    assert numeric_check_digit(value) == expected
+def test_gs1_standard_check_digit(value: str, expected: int) -> None:
+    assert gs1_standard_check_digit(value) == expected
 
 
 @pytest.mark.parametrize("value", ["abc", "⁰⁰⁰"])
-def test_price_check_digit_with_nonnumeric_value(value: str) -> None:
+def test_gs1_price_weight_check_digit_with_nonnumeric_value(value: str) -> None:
     with pytest.raises(
         ValueError,
         match=rf"^Expected numeric value, got {value!r}.$",
     ):
-        price_check_digit(value)
+        gs1_price_weight_check_digit(value)
 
 
 @pytest.mark.parametrize(
@@ -49,12 +49,12 @@ def test_price_check_digit_with_nonnumeric_value(value: str) -> None:
         "123456",
     ],
 )
-def test_price_check_digit_on_values_with_wrong_length(value: str) -> None:
+def test_gs1_price_weight_check_digit_on_values_with_wrong_length(value: str) -> None:
     with pytest.raises(
         ValueError,
         match=rf"^Expected input of length 4 or 5, got {value!r}.$",
     ):
-        price_check_digit(value)
+        gs1_price_weight_check_digit(value)
 
 
 @pytest.mark.parametrize(
@@ -66,5 +66,5 @@ def test_price_check_digit_on_values_with_wrong_length(value: str) -> None:
         ("14685", 6),
     ],
 )
-def test_price_check_digit(value: str, expected: int) -> None:
-    assert price_check_digit(value) == expected
+def test_gs1_price_weight_check_digit(value: str, expected: int) -> None:
+    assert gs1_price_weight_check_digit(value) == expected


### PR DESCRIPTION
- From `biip.gs1.checksums.numeric_check_digit()` to `biip.checksums.gs1_standard_check_digit()`.
- From `biip.gs1.checksums.price_check_digit()` to `biip.checksums.gs1_price_weight_check_digit()`.

Breaking change