### PR TITLE
Always return ParseResult from `biip.parse()`

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,8 +10,7 @@ examples below.
 
 Biip's primary API is the [`biip.parse()`][biip.parse] function. It accepts a
 string of data from a barcode scanner and returns a
-[`biip.ParseResult`][biip.ParseResult] object with any results or raises a
-[`biip.ParseError`][biip.ParseError] if all parsers fail.
+[`biip.ParseResult`][biip.ParseResult] object with any results.
 
 Nearly all products you can buy in a store are marked with an UPC or
 EAN-13 barcode. These barcodes contain a number called GTIN, short for
@@ -51,19 +50,25 @@ can see that the data is successfully parsed as a GTIN while parsing as
 an SSCC or GS1 Message failed, and Biip returned error messages
 explaining why.
 
-If all parsers fail, Biip raises a [`biip.ParseError`][biip.ParseError]. The
-exception's string representation contains detailed error messages explaining
-why each parser failed to interpret the provided data:
+If all parsers fail, Biip still returns a
+[`biip.ParseResult`][biip.ParseResult]. The result's error fields contains
+detailed error messages explaining why each parser failed to interpret the
+provided data:
 
 ```python
 >>> biip.parse("12345678")
-Traceback (most recent call last):
-    ...
-biip._exceptions.ParseError: Failed to parse '12345678':
-- Invalid GTIN check digit for '12345678': Expected 0, got 8.
-- UPC: Invalid UPC-E check digit for '12345678': Expected 0, got 8.
-- Failed to parse '12345678' as SSCC: Expected 18 digits, got 8.
-- Failed to parse GS1 AI (12) date from '345678'.
+ParseResult(
+    value='12345678',
+    symbology_identifier=None,
+    gtin=None,
+    gtin_error="Invalid GTIN check digit for '12345678': Expected 0, got 8.",
+    upc=None,
+    upc_error="Invalid UPC-E check digit for '12345678': Expected 0, got 8.",
+    sscc=None,
+    sscc_error="Failed to parse '12345678' as SSCC: Expected 18 digits, got 8.",
+    gs1_message=None,
+    gs1_message_error="Failed to match '12345678' with GS1 AI (12) pattern '^12(\\d{2}(?:0\\d|1[0-2])(?:[0-2]\\d|3[01]))$'.",
+)
 ```
 
 Biip always checks that the GTIN check digit is correct. If the check

--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -57,7 +57,7 @@ GTIN. If a format includes check digits, Biip always control them and fail if
 the check digits are incorrect.
 
     >>> result = biip.parse("15210527")
-    >>> print(result.gtin)
+    >>> pprint(result.gtin)
     None
     >>> result.gtin_error
     "Invalid GTIN check digit for '15210527': Expected 4, got 7."
@@ -91,17 +91,23 @@ the check digits are incorrect.
         ]
     )
 
-If a value cannot be interpreted as any supported format, an exception is
-raised with a reason from each parser.
+If a value cannot be interpreted as any supported format, you still get a
+`ParseResult` object with all result fields set to `None`.
 
-    >>> biip.parse("123")
-    Traceback (most recent call last):
-        ...
-    biip._exceptions.ParseError: Failed to parse '123':
-    - GTIN: Failed to parse '123' as GTIN: Expected 8, 12, 13, or 14 digits, got 3.
-    - UPC: Failed to parse '123' as UPC: Expected 6, 7, 8, or 12 digits, got 3.
-    - SSCC: Failed to parse '123' as SSCC: Expected 18 digits, got 3.
-    - GS1: Failed to match '123' with GS1 AI (12) pattern '^12(\d{2}(?:0\d|1[0-2])(?:[0-2]\d|3[01]))$'.
+    >>> result = biip.parse("123")
+    >>> pprint(result)
+    ParseResult(
+        value='123',
+        symbology_identifier=None,
+        gtin=None,
+        gtin_error="Failed to parse '123' as GTIN: Expected 8, 12, 13, or 14 digits, got 3.",
+        upc=None,
+        upc_error="Failed to parse '123' as UPC: Expected 6, 7, 8, or 12 digits, got 3.",
+        sscc=None,
+        sscc_error="Failed to parse '123' as SSCC: Expected 18 digits, got 3.",
+        gs1_message=None,
+        gs1_message_error="Failed to match '123' with GS1 AI (12) pattern '^12(\\d{2}(?:0\\d|1[0-2])(?:[0-2]\\d|3[01]))$'."
+    )
 """  # noqa: E501
 
 from importlib.metadata import (  # pyright: ignore[reportMissingImports]

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -48,9 +48,6 @@ def parse(
 
     Returns:
         A data class depending upon what type of data is parsed.
-
-    Raises:
-        ParseError: If parsing of the data fails.
     """
     value = value.strip()
     config = ParseConfig(
@@ -91,11 +88,7 @@ def parse(
         (parse_func, val) = queue.pop(0)
         parse_func(val, config, queue, result)
 
-    if result._has_result():  # noqa: SLF001
-        return result
-
-    msg = f"Failed to parse {value!r}:\n{result._get_errors_list()}"  # noqa: SLF001
-    raise ParseError(msg)
+    return result
 
 
 @dataclass
@@ -148,21 +141,6 @@ class ParseResult:
 
     If parsing as a GS1 Message was attempted and failed.
     """
-
-    def _has_result(self) -> bool:
-        return any([self.gtin, self.upc, self.sscc, self.gs1_message])
-
-    def _get_errors_list(self) -> str:
-        return "\n".join(
-            f"- {parser_name}: {error}"
-            for parser_name, error in [
-                ("GTIN", self.gtin_error),
-                ("UPC", self.upc_error),
-                ("SSCC", self.sscc_error),
-                ("GS1", self.gs1_message_error),
-            ]
-            if error is not None
-        )
 
 
 ParseQueue = list[tuple["Parser", str]]

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 import pytest
 
-from biip import ParseError, ParseResult, parse
+from biip import ParseResult, parse
 from biip.gs1 import (
     GS1ApplicationIdentifier,
     GS1CompanyPrefix,
@@ -723,15 +723,24 @@ def test_parse_with_separator_char() -> None:
 
 
 def test_parse_invalid_data() -> None:
-    with pytest.raises(ParseError) as exc_info:
-        parse("abc")
+    result = parse("abc")
 
-    assert str(exc_info.value) == (
-        "Failed to parse 'abc':\n"
-        "- GTIN: Failed to parse 'abc' as GTIN: "
-        "Expected 8, 12, 13, or 14 digits, got 3.\n"
-        "- UPC: Failed to parse 'abc' as UPC: "
-        "Expected 6, 7, 8, or 12 digits, got 3.\n"
-        "- SSCC: Failed to parse 'abc' as SSCC: Expected 18 digits, got 3.\n"
-        "- GS1: Failed to get GS1 Application Identifier from 'abc'."
+    assert result.gtin is None
+    assert (
+        result.gtin_error
+        == "Failed to parse 'abc' as GTIN: Expected 8, 12, 13, or 14 digits, got 3."
+    )
+    assert result.gs1_message is None
+    assert (
+        result.gs1_message_error
+        == "Failed to get GS1 Application Identifier from 'abc'."
+    )
+    assert result.sscc is None
+    assert (
+        result.sscc_error == "Failed to parse 'abc' as SSCC: Expected 18 digits, got 3."
+    )
+    assert result.upc is None
+    assert (
+        result.upc_error
+        == "Failed to parse 'abc' as UPC: Expected 6, 7, 8, or 12 digits, got 3."
     )


### PR DESCRIPTION
This makes it a bit easier to use `biip.parse()` as you will no longer need to catch `ParseError` to handle all cases.

This isn't a breaking change unless you relied on `parse()` to raise when no parsing attempt succeeds.