### PR TITLE
Add support Rich's pretty printing

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,16 @@ see the [documentation](https://biip.readthedocs.io/).
 ## Example
 
 ```python
+>>> from rich import print
 >>> import biip
->>> biip.parse("]E09781492053743")
+>>> print(biip.parse("]E09781492053743"))
 ParseResult(
     value=']E09781492053743',
     symbology_identifier=SymbologyIdentifier(
         value=']E0',
         symbology=Symbology.EAN_UPC,
         modifiers='0',
-        gs1_symbology=GS1Symbology.EAN_13,
+        gs1_symbology=GS1Symbology.EAN_13
     ),
     gtin=Gtin(
         value='9781492053743',
@@ -43,16 +44,8 @@ ParseResult(
         prefix=GS1Prefix(value='978', usage='Bookland (ISBN)'),
         company_prefix=None,
         payload='978149205374',
-        check_digit=3,
-        packaging_level=None,
-    ),
-    gtin_error=None,
-    upc=None,
-    upc_error=None,
-    sscc=None,
-    sscc_error=None,
-    gs1_message=None,
-    gs1_message_error=None,
+        check_digit=3
+    )
 )
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,15 +17,16 @@ The library can interpret the following formats:
 ## Example
 
 ```python
+>>> from rich import print
 >>> import biip
->>> biip.parse("]E09781492053743")
+>>> print(biip.parse("]E09781492053743"))
 ParseResult(
     value=']E09781492053743',
     symbology_identifier=SymbologyIdentifier(
         value=']E0',
         symbology=Symbology.EAN_UPC,
         modifiers='0',
-        gs1_symbology=GS1Symbology.EAN_13,
+        gs1_symbology=GS1Symbology.EAN_13
     ),
     gtin=Gtin(
         value='9781492053743',
@@ -33,16 +34,8 @@ ParseResult(
         prefix=GS1Prefix(value='978', usage='Bookland (ISBN)'),
         company_prefix=None,
         payload='978149205374',
-        check_digit=3,
-        packaging_level=None,
-    ),
-    gtin_error=None,
-    upc=None,
-    upc_error=None,
-    sscc=None,
-    sscc_error=None,
-    gs1_message=None,
-    gs1_message_error=None,
+        check_digit=3
+    )
 )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ branch = true
 source_pkgs = ["biip"]
 
 [tool.coverage.report]
-exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:"]
+exclude_lines = ["pragma: no cover", "if TYPE_CHECKING:", "def __rich_repr__"]
 fail_under = 100
 show_missing = true
 

--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -18,8 +18,7 @@ example, the value can be interpreted as either a GTIN or a GS1 Message.
             value='0000963'
         ),
         payload='9638507',
-        check_digit=4,
-        packaging_level=None
+        check_digit=4
     )
     >>> pprint(result.gs1_message)
     GS1Message(
@@ -36,17 +35,7 @@ example, the value can be interpreted as either a GTIN or a GS1 Message.
                 value='385074',
                 pattern_groups=[
                     '385074'
-                ],
-                gln=None,
-                gln_error=None,
-                gtin=None,
-                gtin_error=None,
-                sscc=None,
-                sscc_error=None,
-                date=None,
-                datetime=None,
-                decimal=None,
-                money=None
+                ]
             )
         ]
     )
@@ -77,16 +66,7 @@ the check digits are incorrect.
                 pattern_groups=[
                     '210527'
                 ],
-                gln=None,
-                gln_error=None,
-                gtin=None,
-                gtin_error=None,
-                sscc=None,
-                sscc_error=None,
-                date=datetime.date(2021, 5, 27),
-                datetime=None,
-                decimal=None,
-                money=None
+                date=datetime.date(2021, 5, 27)
             )
         ]
     )
@@ -98,14 +78,9 @@ If a value cannot be interpreted as any supported format, you still get a
     >>> pprint(result)
     ParseResult(
         value='123',
-        symbology_identifier=None,
-        gtin=None,
         gtin_error="Failed to parse '123' as GTIN: Expected 8, 12, 13, or 14 digits, got 3.",
-        upc=None,
         upc_error="Failed to parse '123' as UPC: Expected 6, 7, 8, or 12 digits, got 3.",
-        sscc=None,
         sscc_error="Failed to parse '123' as SSCC: Expected 18 digits, got 3.",
-        gs1_message=None,
         gs1_message_error="Failed to match '123' with GS1 AI (12) pattern '^12(\\d{2}(?:0\\d|1[0-2])(?:[0-2]\\d|3[01]))$'."
     )
 """  # noqa: E501

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Callable, Optional
+from typing import TYPE_CHECKING, Any, Callable, Optional, Union
 
 from biip import ParseError
 from biip.gs1 import DEFAULT_SEPARATOR_CHARS, GS1Message, GS1Symbology
@@ -13,7 +13,7 @@ from biip.symbology import SymbologyIdentifier
 from biip.upc import Upc
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
 
 def parse(
@@ -141,6 +141,19 @@ class ParseResult:
 
     If parsing as a GS1 Message was attempted and failed.
     """
+
+    def __rich_repr__(self) -> Iterator[Union[tuple[str, Any], tuple[str, Any, Any]]]:
+        # Skip printing fields with default values
+        yield "value", self.value
+        yield "symbology_identifier", self.symbology_identifier, None
+        yield "gtin", self.gtin, None
+        yield "gtin_error", self.gtin_error, None
+        yield "upc", self.upc, None
+        yield "upc_error", self.upc_error, None
+        yield "sscc", self.sscc, None
+        yield "sscc_error", self.sscc_error, None
+        yield "gs1_message", self.gs1_message, None
+        yield "gs1_message_error", self.gs1_message_error, None
 
 
 ParseQueue = list[tuple["Parser", str]]

--- a/src/biip/gs1/__init__.py
+++ b/src/biip/gs1/__init__.py
@@ -56,8 +56,6 @@ In this example, the first element string is a GTIN.
         pattern_groups=[
             '07032069804988'
         ],
-        gln=None,
-        gln_error=None,
         gtin=Gtin(
             value='07032069804988',
             format=GtinFormat.GTIN_13,
@@ -69,16 +67,8 @@ In this example, the first element string is a GTIN.
                 value='703206'
             ),
             payload='703206980498',
-            check_digit=8,
-            packaging_level=None
-        ),
-        gtin_error=None,
-        sscc=None,
-        sscc_error=None,
-        date=None,
-        datetime=None,
-        decimal=None,
-        money=None
+            check_digit=8
+        )
     )
 
 The message object has [`msg.get()`][biip.gs1.GS1Message.get] and
@@ -98,16 +88,7 @@ either by the Application Identifier's "data title" or its AI number.
         pattern_groups=[
             '210526'
         ],
-        gln=None,
-        gln_error=None,
-        gtin=None,
-        gtin_error=None,
-        sscc=None,
-        sscc_error=None,
-        date=datetime.date(2021, 5, 26),
-        datetime=None,
-        decimal=None,
-        money=None
+        date=datetime.date(2021, 5, 26)
     )
     >>> pprint(msg.get(ai="10"))
     GS1ElementString(
@@ -121,17 +102,7 @@ either by the Application Identifier's "data title" or its AI number.
         value='0329',
         pattern_groups=[
             '0329'
-        ],
-        gln=None,
-        gln_error=None,
-        gtin=None,
-        gtin_error=None,
-        sscc=None,
-        sscc_error=None,
-        date=None,
-        datetime=None,
-        decimal=None,
-        money=None
+        ]
     )
 """
 

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import calendar
 import datetime as dt
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from biip import ParseError
 from biip.gln import Gln
@@ -317,6 +318,22 @@ class GS1ElementString:
     def __len__(self) -> int:
         """Get the length of the element string."""
         return len(self.ai) + len(self.value)
+
+    def __rich_repr__(self) -> Iterator[Union[tuple[str, Any], tuple[str, Any, Any]]]:
+        # Skip printing fields with default values
+        yield "ai", self.ai
+        yield "value", self.value
+        yield "pattern_groups", self.pattern_groups
+        yield "gln", self.gln, None
+        yield "gln_error", self.gln_error, None
+        yield "gtin", self.gtin, None
+        yield "gtin_error", self.gtin_error, None
+        yield "sscc", self.sscc, None
+        yield "sscc_error", self.sscc_error, None
+        yield "date", self.date, None
+        yield "datetime", self.datetime, None
+        yield "decimal", self.decimal, None
+        yield "money", self.money, None
 
     def as_hri(self) -> str:
         """Render as a human readable interpretation (HRI).

--- a/src/biip/gs1/_element_strings.py
+++ b/src/biip/gs1/_element_strings.py
@@ -17,7 +17,7 @@ from biip.gtin import Gtin, RcnRegion
 from biip.sscc import Sscc
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Iterator
 
 try:
     import moneyed  # noqa: TC002
@@ -52,8 +52,6 @@ class GS1ElementString:
             pattern_groups=[
                 '07032069804988'
             ],
-            gln=None,
-            gln_error=None,
             gtin=Gtin(
                 value='07032069804988',
                 format=GtinFormat.GTIN_13,
@@ -65,16 +63,8 @@ class GS1ElementString:
                     value='703206'
                 ),
                 payload='703206980498',
-                check_digit=8,
-                packaging_level=None
-            ),
-            gtin_error=None,
-            sscc=None,
-            sscc_error=None,
-            date=None,
-            datetime=None,
-            decimal=None,
-            money=None
+                check_digit=8
+            )
         )
         >>> element_string.as_hri()
         '(01)07032069804988'

--- a/src/biip/gtin/__init__.py
+++ b/src/biip/gtin/__init__.py
@@ -31,8 +31,7 @@ If parsing succeeds, it returns a [`Gtin`][biip.gtin.Gtin] object.
             value='703206'
         ),
         payload='703206980498',
-        check_digit=8,
-        packaging_level=None
+        check_digit=8
     )
 
 A GTIN can be converted to any other GTIN format, as long as the target

--- a/src/biip/gtin/_gtin.py
+++ b/src/biip/gtin/_gtin.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from biip import EncodeError, ParseError
 from biip.checksums import gs1_standard_check_digit
@@ -162,6 +163,16 @@ class Gtin:
             )
 
         return gtin
+
+    def __rich_repr__(self) -> Iterator[Union[tuple[str, Any], tuple[str, Any, Any]]]:
+        # Skip printing fields with default values
+        yield "value", self.value
+        yield "format", self.format
+        yield "prefix", self.prefix
+        yield "company_prefix", self.company_prefix
+        yield "payload", self.payload
+        yield "check_digit", self.check_digit
+        yield "packaging_level", self.packaging_level, None
 
     def as_gtin_8(self) -> str:
         """Format as a GTIN-8."""

--- a/src/biip/gtin/_gtin.py
+++ b/src/biip/gtin/_gtin.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any, Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from biip import EncodeError, ParseError
 from biip.checksums import gs1_standard_check_digit
 from biip.gs1 import GS1CompanyPrefix, GS1Prefix
 from biip.gtin import GtinFormat, RcnRegion
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 @dataclass

--- a/src/biip/gtin/_rcn.py
+++ b/src/biip/gtin/_rcn.py
@@ -5,11 +5,14 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from decimal import Decimal
 from enum import Enum
-from typing import Optional, Union
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 from biip import EncodeError, ParseError
 from biip.checksums import gs1_price_weight_check_digit, gs1_standard_check_digit
 from biip.gtin import Gtin, RcnRegion, RcnUsage
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 try:
     import moneyed  # noqa: TC002
@@ -68,6 +71,16 @@ class Rcn(Gtin):
     def __post_init__(self) -> None:
         """Initialize derivated fields."""
         self._set_usage()
+
+    def __rich_repr__(self) -> Iterator[Union[tuple[str, Any], tuple[str, Any, Any]]]:
+        # Skip printing fields with default values
+        yield from super().__rich_repr__()
+        yield "usage", self.usage, None
+        yield "region", self.region, None
+        yield "weight", self.weight, None
+        yield "count", self.count, None
+        yield "price", self.price, None
+        yield "money", self.money, None
 
     def _set_usage(self) -> None:
         # Classification as RCN depends on the prefix being known, so we won't


### PR DESCRIPTION
Mostly motivated by making examples and docstrings examples less verbose, but should be useful for anyone using Biip together with `rich.print`.