### PR TITLE
Drop support for Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "pytest (3.9)"
-            python: "3.9"
-            tox: "3.9"
           - name: "pytest (3.10)"
             python: "3.10"
             tox: "3.10"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,9 +44,9 @@ jobs:
           - name: "ruff format"
             python: "3.13"
             tox: ruff-format
-          - name: "ruff lint"
+          - name: "ruff check"
             python: "3.13"
-            tox: ruff-lint
+            tox: ruff-check
           - name: "Docs"
             python: "3.13"
             tox: docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,7 +158,7 @@ env_list = [
     "mypy",
     "pyright",
     "ruff-format",
-    "ruff-lint",
+    "ruff-check",
 ]
 
 [tool.tox.env_run_base]
@@ -213,7 +213,7 @@ skip_install = true
 dependency_groups = ["ruff"]
 commands = [["ruff", "format", "--check", "{posargs:.}"]]
 
-[tool.tox.env.ruff-lint]
+[tool.tox.env.ruff-check]
 skip_install = true
 dependency_groups = ["ruff"]
 commands = [["ruff", "check", "{posargs:.}"]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "biip"
 version = "3.6.0"
 description = "Biip interprets the data in barcodes."
 authors = [{ name = "Stein Magnus Jodal", email = "stein.magnus@jodal.no" }]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 readme = "README.md"
 license = "Apache-2.0"
 keywords = ["barcodes", "ean", "isbn", "gs1", "gtin", "upc"]
@@ -93,7 +93,7 @@ disallow_untyped_defs = true
 
 
 [tool.pyright]
-pythonVersion = "3.9"
+pythonVersion = "3.10"
 typeCheckingMode = "strict"
 # Already covered by tests and careful import ordering:
 reportImportCycles = false
@@ -151,7 +151,6 @@ keep-runtime-typing = true
 
 [tool.tox]
 env_list = [
-    "3.9",
     "3.10",
     "3.11",
     "3.12",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,9 +101,6 @@ reportImportCycles = false
 reportPrivateUsage = false
 
 
-[tool.ruff]
-target-version = "py39"
-
 [tool.ruff.lint]
 preview = true
 explicit-preview-rules = true
@@ -116,6 +113,7 @@ select = [
     "DOC402", # docstring-missing-yields
     "DOC403", # docstring-extraneous-yields
     "DOC501", # docstring-missing-exception
+    "UP045",  # non-pep604-annotation-optional
 ]
 ignore = [
     "PLR2004", # magic-value-comparison

--- a/scripts/download_gs1_company_prefixes.py
+++ b/scripts/download_gs1_company_prefixes.py
@@ -6,7 +6,7 @@ from xml.etree import ElementTree  # noqa: ICN001
 
 import httpx
 
-TrieNode = Union[dict[str, "TrieNode"], int]
+TrieNode = Union[dict[str, "TrieNode"], int]  # noqa: UP007
 
 COMPANY_PREFIX_URL = "https://www.gs1.org/docs/gcp_length/gcpprefixformatlist.xml"
 

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from biip import ParseError
 from biip.gs1_messages import DEFAULT_SEPARATOR_CHARS, GS1Message
@@ -21,7 +22,7 @@ if TYPE_CHECKING:
 def parse(
     value: str,
     *,
-    rcn_region: Optional[RcnRegion] = None,
+    rcn_region: RcnRegion | None = None,
     rcn_verify_variable_measure: bool = True,
     separator_chars: Iterable[str] = DEFAULT_SEPARATOR_CHARS,
 ) -> ParseResult:
@@ -97,7 +98,7 @@ def parse(
 class ParseConfig:
     """Configuration options for parsers."""
 
-    rcn_region: Optional[RcnRegion]
+    rcn_region: RcnRegion | None
     rcn_verify_variable_measure: bool
     separator_chars: Iterable[str]
 
@@ -109,42 +110,42 @@ class ParseResult:
     value: str
     """The raw value. Only stripped of surrounding whitespace."""
 
-    symbology_identifier: Optional[SymbologyIdentifier] = None
+    symbology_identifier: SymbologyIdentifier | None = None
     """The Symbology Identifier, if any."""
 
-    gtin: Optional[Gtin] = None
+    gtin: Gtin | None = None
     """The extracted [GTIN][biip.gtin.Gtin], if any.
 
     Is also set if a GS1 Message containing a GTIN was successfully parsed."""
 
-    gtin_error: Optional[str] = None
+    gtin_error: str | None = None
     """The GTIN parse error, if parsing as a GTIN was attempted and failed."""
 
-    upc: Optional[Upc] = None
+    upc: Upc | None = None
     """The extracted [UPC][biip.upc.Upc], if any."""
 
-    upc_error: Optional[str] = None
+    upc_error: str | None = None
     """The UPC parse error, if parsing as an UPC was attempted and failed."""
 
-    sscc: Optional[Sscc] = None
+    sscc: Sscc | None = None
     """The extracted [SSCC][biip.sscc.Sscc], if any.
 
     Is also set if a GS1 Message containing an SSCC was successfully parsed.
     """
 
-    sscc_error: Optional[str] = None
+    sscc_error: str | None = None
     """The SSCC parse error, if parsing as an SSCC was attempted and failed."""
 
-    gs1_message: Optional[GS1Message] = None
+    gs1_message: GS1Message | None = None
     """The extracted [GS1 Message][biip.gs1_messages.GS1Message], if any."""
 
-    gs1_message_error: Optional[str] = None
+    gs1_message_error: str | None = None
     """The GS1 Message parse error.
 
     If parsing as a GS1 Message was attempted and failed.
     """
 
-    def __rich_repr__(self) -> Iterator[Union[tuple[str, Any], tuple[str, Any, Any]]]:
+    def __rich_repr__(self) -> Iterator[tuple[str, Any] | tuple[str, Any, Any]]:
         # Skip printing fields with default values
         yield "value", self.value
         yield "symbology_identifier", self.symbology_identifier, None

--- a/src/biip/checksums.py
+++ b/src/biip/checksums.py
@@ -78,7 +78,7 @@ def gs1_price_weight_check_digit(value: str) -> int:
 def _four_digit_price_weight_check_digit(value: str) -> int:
     digits = list(map(int, list(value)))
     weight_sum = 0
-    for digit, weight_map in zip(digits, _FOUR_DIGIT_POSITION_WEIGHTS):
+    for digit, weight_map in zip(digits, _FOUR_DIGIT_POSITION_WEIGHTS, strict=True):
         weight = weight_map[digit]
         weight_sum += weight
     return (weight_sum * 3) % 10
@@ -87,7 +87,7 @@ def _four_digit_price_weight_check_digit(value: str) -> int:
 def _five_digit_price_weight_check_digit(value: str) -> int:
     digits = list(map(int, list(value)))
     weighted_sum = 0
-    for digit, weight_map in zip(digits, _FIVE_DIGIT_POSITION_WEIGHTS):
+    for digit, weight_map in zip(digits, _FIVE_DIGIT_POSITION_WEIGHTS, strict=True):
         weight = weight_map[digit]
         weighted_sum += weight
     result = (10 - weighted_sum % 10) % 10

--- a/src/biip/gln.py
+++ b/src/biip/gln.py
@@ -53,7 +53,6 @@ validated using the [`Gln`][biip.gln.Gln] class.
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 from biip import ParseError
 from biip.checksums import gs1_standard_check_digit
@@ -67,13 +66,13 @@ class Gln:
     value: str
     """Raw unprocessed value."""
 
-    prefix: Optional[GS1Prefix]
+    prefix: GS1Prefix | None
     """The [GS1 Prefix][biip.gs1_prefixes.GS1Prefix].
 
     Indicating what GS1 country organization that assigned code range.
     """
 
-    company_prefix: Optional[GS1CompanyPrefix]
+    company_prefix: GS1CompanyPrefix | None
     """The [GS1 Company Prefix][biip.gs1_prefixes.GS1CompanyPrefix].
 
     Identifying the company that issued the GLN.

--- a/src/biip/gs1_messages/_element_strings.py
+++ b/src/biip/gs1_messages/_element_strings.py
@@ -8,7 +8,7 @@ import re
 from collections.abc import Iterator
 from dataclasses import dataclass
 from decimal import Decimal
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from biip import ParseError
 from biip.gln import Gln
@@ -82,35 +82,35 @@ class GS1ElementString:
     pattern_groups: list[str]
     """List of pattern groups extracted from the Element String."""
 
-    gln: Optional[Gln] = None
+    gln: Gln | None = None
     """A GLN created from the element string, if the AI represents a GLN."""
 
-    gln_error: Optional[str] = None
+    gln_error: str | None = None
     """The GLN parse error, if parsing as a GLN was attempted and failed."""
 
-    gtin: Optional[Gtin] = None
+    gtin: Gtin | None = None
     """A GTIN created from the element string, if the AI represents a GTIN."""
 
-    gtin_error: Optional[str] = None
+    gtin_error: str | None = None
     """The GTIN parse error, if parsing as a GTIN was attempted and failed."""
 
-    sscc: Optional[Sscc] = None
+    sscc: Sscc | None = None
     """An SSCC created from the element string, if the AI represents a SSCC."""
 
-    sscc_error: Optional[str] = None
+    sscc_error: str | None = None
     """The SSCC parse error, if parsing as an SSCC was attempted and failed."""
 
-    date: Optional[dt.date] = None
+    date: dt.date | None = None
     """A date created from the element string, if the AI represents a date."""
 
-    datetime: Optional[dt.datetime] = None
+    datetime: dt.datetime | None = None
     """A datetime created from the element string, if the AI represents a datetime."""
 
-    decimal: Optional[Decimal] = None
+    decimal: Decimal | None = None
     """A decimal value created from the element string, if the AI represents a
     number."""
 
-    money: Optional["moneyed.Money"] = None  # noqa: UP037
+    money: moneyed.Money | None = None
     """A Money value created from the element string, if the AI represents a
     currency and an amount.
 
@@ -122,7 +122,7 @@ class GS1ElementString:
         cls,
         value: str,
         *,
-        rcn_region: Optional[RcnRegion] = None,
+        rcn_region: RcnRegion | None = None,
         rcn_verify_variable_measure: bool = True,
         separator_chars: Iterable[str] = DEFAULT_SEPARATOR_CHARS,
     ) -> GS1ElementString:
@@ -216,7 +216,7 @@ class GS1ElementString:
     def _set_gtin(
         self,
         *,
-        rcn_region: Optional[RcnRegion],
+        rcn_region: RcnRegion | None,
         rcn_verify_variable_measure: bool,
     ) -> None:
         if self.ai.ai not in ("01", "02"):
@@ -312,7 +312,7 @@ class GS1ElementString:
         """Get the length of the element string."""
         return len(self.ai) + len(self.value)
 
-    def __rich_repr__(self) -> Iterator[Union[tuple[str, Any], tuple[str, Any, Any]]]:
+    def __rich_repr__(self) -> Iterator[tuple[str, Any] | tuple[str, Any, Any]]:
         # Skip printing fields with default values
         yield "ai", self.ai
         yield "value", self.value
@@ -339,7 +339,7 @@ class GS1ElementString:
         return f"{self.ai}{self.value}"
 
 
-def _parse_date_and_datetime(value: str) -> tuple[dt.date, Optional[dt.datetime]]:
+def _parse_date_and_datetime(value: str) -> tuple[dt.date, dt.datetime | None]:
     pairs = [value[i : i + 2] for i in range(0, len(value), 2)]
 
     year = int(pairs[0])

--- a/src/biip/gs1_messages/_messages.py
+++ b/src/biip/gs1_messages/_messages.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from itertools import chain
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING
 
 from biip import ParseError
 from biip.gs1_application_identifiers import (
@@ -45,7 +45,7 @@ class GS1Message:
         cls,
         value: str,
         *,
-        rcn_region: Optional[RcnRegion] = None,
+        rcn_region: RcnRegion | None = None,
         rcn_verify_variable_measure: bool = True,
         separator_chars: Iterable[str] = DEFAULT_SEPARATOR_CHARS,
     ) -> GS1Message:
@@ -101,7 +101,7 @@ class GS1Message:
         cls,
         value: str,
         *,
-        rcn_region: Optional[RcnRegion] = None,
+        rcn_region: RcnRegion | None = None,
         rcn_verify_variable_measure: bool = True,
     ) -> GS1Message:
         """Parse the GS1 string given in HRI (human readable interpretation) format.
@@ -173,8 +173,8 @@ class GS1Message:
     def filter(
         self,
         *,
-        ai: Optional[Union[str, GS1ApplicationIdentifier]] = None,
-        data_title: Optional[str] = None,
+        ai: str | GS1ApplicationIdentifier | None = None,
+        data_title: str | None = None,
     ) -> list[GS1ElementString]:
         """Filter Element Strings by AI or data title.
 
@@ -205,9 +205,9 @@ class GS1Message:
     def get(
         self,
         *,
-        ai: Optional[Union[str, GS1ApplicationIdentifier]] = None,
-        data_title: Optional[str] = None,
-    ) -> Optional[GS1ElementString]:
+        ai: str | GS1ApplicationIdentifier | None = None,
+        data_title: str | None = None,
+    ) -> GS1ElementString | None:
         """Get Element String by AI or data title.
 
         Args:

--- a/src/biip/gs1_prefixes/__init__.py
+++ b/src/biip/gs1_prefixes/__init__.py
@@ -27,7 +27,7 @@ import json
 import lzma
 from dataclasses import dataclass
 from importlib import resources
-from typing import Optional, Union
+from typing import Union
 
 from biip import ParseError
 
@@ -36,7 +36,7 @@ __all__ = [
     "GS1Prefix",
 ]
 
-_TrieNode = Union[dict[str, "_TrieNode"], int]
+_TrieNode = Union[dict[str, "_TrieNode"], int]  # noqa: UP007
 
 
 @dataclass(frozen=True)
@@ -65,7 +65,7 @@ class GS1Prefix:
     """Description of who is using the prefix."""
 
     @classmethod
-    def extract(cls, value: str) -> Optional[GS1Prefix]:
+    def extract(cls, value: str) -> GS1Prefix | None:
         """Extract the GS1 Prefix from the given value.
 
         Args:
@@ -114,7 +114,7 @@ class GS1CompanyPrefix:
     """The company prefix itself."""
 
     @classmethod
-    def extract(cls, value: str) -> Optional[GS1CompanyPrefix]:
+    def extract(cls, value: str) -> GS1CompanyPrefix | None:
         """Extract the GS1 Company Prefix from the given value.
 
         Args:

--- a/src/biip/gtin.py
+++ b/src/biip/gtin.py
@@ -52,7 +52,7 @@ from __future__ import annotations
 from collections.abc import Iterator
 from dataclasses import dataclass
 from enum import IntEnum
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from biip import EncodeError, ParseError
 from biip.checksums import gs1_standard_check_digit
@@ -112,14 +112,14 @@ class Gtin:
     Classification is done after stripping leading zeros.
     """
 
-    prefix: Optional[GS1Prefix]
+    prefix: GS1Prefix | None
     """The [GS1 Prefix][biip.gs1_prefixes.GS1Prefix].
 
     Indicating what GS1 country organization that assigned
     code range.
     """
 
-    company_prefix: Optional[GS1CompanyPrefix]
+    company_prefix: GS1CompanyPrefix | None
     """The [GS1 Company Prefix][biip.gs1_prefixes.GS1CompanyPrefix].
 
     Identifying the company that issued the GTIN.
@@ -135,7 +135,7 @@ class Gtin:
     check_digit: int
     """Check digit used to check if the GTIN as a whole is valid."""
 
-    packaging_level: Optional[int] = None
+    packaging_level: int | None = None
     """Packaging level is the first digit in GTIN-14 codes.
 
     This digit is used for wholesale shipments, e.g. the GTIN-14 product
@@ -148,7 +148,7 @@ class Gtin:
         cls,
         value: str,
         *,
-        rcn_region: Optional[Union[RcnRegion, str]] = None,
+        rcn_region: RcnRegion | str | None = None,
         rcn_verify_variable_measure: bool = True,
     ) -> Gtin:
         """Parse the given value into a [`Gtin`][biip.gtin.Gtin] object.
@@ -197,7 +197,7 @@ class Gtin:
         payload = stripped_value[:-1]
         check_digit = int(stripped_value[-1])
 
-        packaging_level: Optional[int] = None
+        packaging_level: int | None = None
         prefix_value = stripped_value
         if gtin_format == GtinFormat.GTIN_14:
             packaging_level = int(stripped_value[0])
@@ -219,7 +219,7 @@ class Gtin:
             )
             raise ParseError(msg)
 
-        gtin_type: type[Union[Gtin, Rcn]]
+        gtin_type: type[Gtin | Rcn]
         if (
             gtin_format <= GtinFormat.GTIN_13
             and prefix is not None
@@ -247,7 +247,7 @@ class Gtin:
 
         return gtin
 
-    def __rich_repr__(self) -> Iterator[Union[tuple[str, Any], tuple[str, Any, Any]]]:  # noqa: D105
+    def __rich_repr__(self) -> Iterator[tuple[str, Any] | tuple[str, Any, Any]]:  # noqa: D105
         # Skip printing fields with default values
         yield "value", self.value
         yield "format", self.format

--- a/src/biip/rcn.py
+++ b/src/biip/rcn.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from decimal import Decimal
 from enum import Enum
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from biip import EncodeError, ParseError
 from biip.checksums import gs1_price_weight_check_digit, gs1_standard_check_digit
@@ -92,7 +92,7 @@ class RcnRegion(Enum):
         """Canonical string representation of format."""
         return f"RcnRegion.{self.name}"
 
-    def get_currency_code(self) -> Optional[str]:
+    def get_currency_code(self) -> str | None:
         """Get the ISO-4217 currency code for the region."""
         return {
             RcnRegion.DENMARK: "DKK",
@@ -112,25 +112,25 @@ class Rcn(Gtin):
     to parse.
     """
 
-    usage: Optional[RcnUsage] = field(default=None)
+    usage: RcnUsage | None = field(default=None)
     """Where the RCN can be circulated, in a geographical region or within a company."""
 
-    region: Optional[RcnRegion] = field(default=None)
+    region: RcnRegion | None = field(default=None)
     """The geographical region.
 
     The region's rules are used to interpret the contents of the RCN.
     """
 
-    weight: Optional[Decimal] = field(default=None)
+    weight: Decimal | None = field(default=None)
     """A variable weight value extracted from the GTIN."""
 
-    count: Optional[int] = field(default=None)
+    count: int | None = field(default=None)
     """A variable count extracted from the GTIN."""
 
-    price: Optional[Decimal] = field(default=None)
+    price: Decimal | None = field(default=None)
     """A variable weight price extracted from the GTIN."""
 
-    money: Optional["moneyed.Money"] = field(default=None)  # noqa: UP037
+    money: moneyed.Money | None = field(default=None)
     """A Money value created from the variable weight price.
 
     Only set if [`py-moneyed`](https://pypi.org/project/py-moneyed/) is
@@ -141,7 +141,7 @@ class Rcn(Gtin):
         """Initialize derivated fields."""
         self._set_usage()
 
-    def __rich_repr__(self) -> Iterator[Union[tuple[str, Any], tuple[str, Any, Any]]]:  # noqa: D105
+    def __rich_repr__(self) -> Iterator[tuple[str, Any] | tuple[str, Any, Any]]:  # noqa: D105
         # Skip printing fields with default values
         yield from super().__rich_repr__()
         yield "usage", self.usage, None
@@ -164,7 +164,7 @@ class Rcn(Gtin):
     def _parse_with_regional_rules(
         self,
         *,
-        region: Union[RcnRegion, str],
+        region: RcnRegion | str,
         verify_variable_measure: bool,
     ) -> None:
         if self.usage == RcnUsage.COMPANY:
@@ -249,10 +249,10 @@ class _Strategy:
 
     prefix_slice: slice = field(init=False)
     value_slice: slice = field(init=False)
-    check_digit_slice: Optional[slice] = field(init=False)
+    check_digit_slice: slice | None = field(init=False)
 
     @classmethod
-    def get_for_rcn(cls, rcn: Rcn) -> Optional[_Strategy]:
+    def get_for_rcn(cls, rcn: Rcn) -> _Strategy | None:
         # The RCN's geographical region must be known to lookup the correct
         # strategy for interpreting the RCN's variable measure.
         assert rcn.region is not None
@@ -282,7 +282,7 @@ class _Strategy:
         self.value_slice = value_slice
         self.check_digit_slice = self._get_pattern_slice("C")
 
-    def _get_pattern_slice(self, char: str) -> Optional[slice]:
+    def _get_pattern_slice(self, char: str) -> slice | None:
         if char not in self.pattern:
             return None
         return slice(self.pattern.index(char), self.pattern.rindex(char) + 1)

--- a/src/biip/sscc.py
+++ b/src/biip/sscc.py
@@ -41,7 +41,6 @@ If the detected GS1 Company Prefix length is wrong, it can be overridden:
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
 
 from biip import ParseError
 from biip.checksums import gs1_standard_check_digit
@@ -55,13 +54,13 @@ class Sscc:
     value: str
     """Raw unprocessed value."""
 
-    prefix: Optional[GS1Prefix]
+    prefix: GS1Prefix | None
     """The GS1 Prefix.
 
     Indicating what GS1 country organization that assigned code range.
     """
 
-    company_prefix: Optional[GS1CompanyPrefix]
+    company_prefix: GS1CompanyPrefix | None
     """The GS1 Company Prefix.
 
     Identifying the company that issued the SSCC.
@@ -132,7 +131,7 @@ class Sscc:
             check_digit=check_digit,
         )
 
-    def as_hri(self, *, company_prefix_length: Optional[int] = None) -> str:
+    def as_hri(self, *, company_prefix_length: int | None = None) -> str:
         """Render as a human readable interpretation (HRI).
 
         The HRI is often printed directly below barcodes.

--- a/src/biip/symbology.py
+++ b/src/biip/symbology.py
@@ -36,7 +36,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
 
 from biip import ParseError
 
@@ -234,7 +233,7 @@ class SymbologyIdentifier:
     or ISO/IEC 15424 for interpretation.
     """
 
-    gs1_symbology: Optional[GS1Symbology] = None
+    gs1_symbology: GS1Symbology | None = None
     """If the Symbology Identifier is used in the GS1 system,
     this field is set to indicate how to interpret the following data.
     """
@@ -277,7 +276,7 @@ class SymbologyIdentifier:
 
         value = f"]{iso_symbology.value}{modifiers}"
 
-        gs1_symbology: Optional[GS1Symbology]
+        gs1_symbology: GS1Symbology | None
         try:
             gs1_symbology = GS1Symbology(f"{iso_symbology.value}{modifiers}")
         except ValueError:

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -63,7 +63,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from enum import Enum
-from typing import Optional
 
 from biip import EncodeError, ParseError
 from biip.checksums import gs1_standard_check_digit
@@ -103,7 +102,7 @@ class Upc:
     the check digit.
     """
 
-    check_digit: Optional[int] = None
+    check_digit: int | None = None
     """Check digit used to check if the UPC-A as a whole is valid.
 
     Set for UPC-A, but not set for UPC-E.

--- a/tests/gs1_messages/test_element_strings.py
+++ b/tests/gs1_messages/test_element_strings.py
@@ -1,6 +1,5 @@
 import datetime as dt
 from decimal import Decimal
-from typing import Optional
 
 import pytest
 
@@ -197,7 +196,7 @@ def test_extract_fails_when_not_matching_pattern(ai_code: str, bad_value: str) -
     ],
 )
 def test_extract_date_and_datetime(
-    value: str, expected_date: dt.date, expected_datetime: Optional[dt.datetime]
+    value: str, expected_date: dt.date, expected_datetime: dt.datetime | None
 ) -> None:
     element_string = GS1ElementString.extract(value)
 
@@ -356,7 +355,7 @@ def test_extract_amount_payable(value: str, expected: Decimal) -> None:
     ],
 )
 def test_extract_amount_payable_and_currency(
-    value: str, expected_currency: Optional[str], expected_decimal: Optional[Decimal]
+    value: str, expected_currency: str | None, expected_decimal: Decimal | None
 ) -> None:
     element_string = GS1ElementString.extract(value)
 

--- a/tests/gs1_messages/test_messages.py
+++ b/tests/gs1_messages/test_messages.py
@@ -1,7 +1,6 @@
 import datetime as dt
 from collections.abc import Iterable
 from decimal import Decimal
-from typing import Optional
 
 import pytest
 
@@ -364,7 +363,7 @@ def test_filter_element_strings_by_data_title(
         ("7230EM123\x1d7231EM456\x1d7232EM789", "723", "EM123"),
     ],
 )
-def test_get_element_string_by_ai(value: str, ai: str, expected: Optional[str]) -> None:
+def test_get_element_string_by_ai(value: str, ai: str, expected: str | None) -> None:
     element_string = GS1Message.parse(value).get(ai=ai)
 
     if expected is None:
@@ -386,7 +385,7 @@ def test_get_element_string_by_ai(value: str, ai: str, expected: Optional[str]) 
     ],
 )
 def test_get_element_string_by_data_title(
-    value: str, data_title: str, expected: Optional[str]
+    value: str, data_title: str, expected: str | None
 ) -> None:
     element_string = GS1Message.parse(value).get(data_title=data_title)
 

--- a/tests/rcn/test_rules.py
+++ b/tests/rcn/test_rules.py
@@ -1,5 +1,4 @@
 from decimal import Decimal
-from typing import Optional
 
 import pytest
 from moneyed import Money
@@ -37,9 +36,9 @@ from biip.rcn import Rcn, RcnRegion, RcnUsage
 def test_region_baltics(
     rcn_region: RcnRegion,
     value: str,
-    weight: Optional[Decimal],
-    price: Optional[Decimal],
-    money: Optional[Money],
+    weight: Decimal | None,
+    price: Decimal | None,
+    money: Money | None,
 ) -> None:
     # The three Baltic countries share the same rules and allocation pool.
     #
@@ -70,9 +69,9 @@ def test_region_baltics(
 )
 def test_region_denmark(
     value: str,
-    weight: Optional[Decimal],
-    price: Optional[Decimal],
-    money: Optional[Money],
+    weight: Decimal | None,
+    price: Decimal | None,
+    money: Money | None,
 ) -> None:
     # References:
     #   https://www.gs1.dk/om-gs1/overblik-over-gs1-standarder/gtin-13-pris
@@ -98,9 +97,9 @@ def test_region_denmark(
 )
 def test_region_finland(
     value: str,
-    weight: Optional[Decimal],
-    price: Optional[Decimal],
-    money: Optional[Money],
+    weight: Decimal | None,
+    price: Decimal | None,
+    money: Money | None,
 ) -> None:
     # References:
     #   https://gs1.fi/en/instructions/gs1-company-prefix/how-identify-product-gtin
@@ -134,10 +133,10 @@ def test_region_finland(
 )
 def test_region_germany(
     value: str,
-    weight: Optional[Decimal],
-    count: Optional[int],
-    price: Optional[Decimal],
-    money: Optional[Money],
+    weight: Decimal | None,
+    count: int | None,
+    price: Decimal | None,
+    money: Money | None,
 ) -> None:
     # References:
     #   https://www.gs1-germany.de/fileadmin/gs1/fachpublikationen/globale-artikelnummer-gtin-in-der-anwendung.pdf
@@ -202,9 +201,9 @@ def test_region_germany_when_not_verifying_invalid_check_digit() -> None:
 )
 def test_region_great_britain(
     value: str,
-    weight: Optional[Decimal],
-    price: Optional[Decimal],
-    money: Optional[Money],
+    weight: Decimal | None,
+    price: Decimal | None,
+    money: Money | None,
 ) -> None:
     # References:
     #   https://www.gs1uk.org/how-to-barcode-variable-measure-items
@@ -264,9 +263,9 @@ def test_region_great_britain_when_not_verifying_invalid_check_digit() -> None:
 )
 def test_region_norway(
     value: str,
-    weight: Optional[Decimal],
-    price: Optional[Decimal],
-    money: Optional[Money],
+    weight: Decimal | None,
+    price: Decimal | None,
+    money: Money | None,
 ) -> None:
     # References: TODO: Find specification.
 
@@ -293,9 +292,9 @@ def test_region_norway(
 )
 def test_region_sweden(
     value: str,
-    weight: Optional[Decimal],
-    price: Optional[Decimal],
-    money: Optional[Money],
+    weight: Decimal | None,
+    price: Decimal | None,
+    money: Money | None,
 ) -> None:
     # References:
     #   https://www.gs1.se/en/our-standards/Identify/variable-weight-number1/


### PR DESCRIPTION
This allows us to upgrade the syntax to Python 3.10, replacing the use of `Union[x, y]` with `x | y` and `Optional[x]` with `x | None`. This change is also visible in the API docs, making them more readable.