### PR TITLE
Take all configuration via an explicit `ParseConfig` object

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -218,7 +218,8 @@ region for Biip to be able to extract price or weight from the RCN:
 
 ```python hl_lines="1-2 15-18"
 >>> from biip.rcn import RcnRegion
->>> print(biip.parse("2011122912346", rcn_region=RcnRegion.GREAT_BRITAIN))
+>>> config = biip.ParseConfig(rcn_region=RcnRegion.GREAT_BRITAIN)
+>>> print(biip.parse("2011122912346", config=config))
 ParseResult(
     value='2011122912346',
     gtin=Rcn(
@@ -536,11 +537,14 @@ pipe character, `|`, as this character cannot legally be a part of the
 payload in Element Strings.
 
 If we configure the barcode scanner to use an alternative separator character,
-we also need to tell Biip what character to expect by passing the
-`separator_chars` parameter to the [`parse()`][biip.parse] function:
+we also need to tell Biip what character to expect by creating a
+[`ParseConfig`][biip.ParseConfig] object with the
+[`separator_chars`][biip.ParseConfig.separator_chars] option, and then call the
+[`parse()`][biip.parse] function with the config:
 
 ```python
->>> result = biip.parse("0107032069804988100329|15210525", separator_chars=["|"])
+>>> config = biip.ParseConfig(separator_chars=["|"])
+>>> result = biip.parse("0107032069804988100329|15210525", config=config)
 >>> result.gs1_message.as_hri()
 '(01)07032069804988(10)0329(15)210525'
 ```

--- a/src/biip/__init__.py
+++ b/src/biip/__init__.py
@@ -90,12 +90,14 @@ from importlib.metadata import (  # pyright: ignore[reportMissingImports]
     version,  # pyright: ignore[reportUnknownVariableType]
 )
 
+from biip._config import ParseConfig
 from biip._exceptions import BiipException, EncodeError, ParseError
 from biip._parser import ParseResult, parse
 
 __all__ = [
     "BiipException",
     "EncodeError",
+    "ParseConfig",
     "ParseError",
     "ParseResult",
     "parse",

--- a/src/biip/_config.py
+++ b/src/biip/_config.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+    from biip.rcn import RcnRegion
+
+
+@dataclass(frozen=True)
+class ParseConfig:
+    """Configuration options for parsers.
+
+    Biip strives to do the right thing by default, but you can customize
+    some of its the behavior by setting these options.
+    """
+
+    rcn_region: RcnRegion | str | None = None
+    """The geographical region to use when parsing RCNs.
+
+    Restricted Circulation Numbers (RCN) have different meanings in different
+    geographical regions. Specify your region here so that Biip can use the
+    right parsing rules.
+
+    This must be set to extract variable weight or price from GTINs.
+    """
+
+    rcn_verify_variable_measure: bool = True
+    """
+    Whether to verify that the variable measure in a RCN matches its check digit.
+
+    Some companies use the variable measure check digit for other purposes,
+    requiring this check to be disabled.
+    """
+
+    separator_chars: Iterable[str] = ("\x1d",)
+    """
+    Characters to look for as separators between fields in GS1 messages.
+
+    Defaults to the "group separator" character (byte `0x1d` in ASCII), which is
+    commonly returned by barcode scanners in place of the FNC1 barcode symbol
+    that separates fields.
+
+    If variable-length fields in the middle of the message are not terminated
+    with a separator character, the parser might greedily consume the rest of
+    the message.
+    """

--- a/src/biip/gln.py
+++ b/src/biip/gln.py
@@ -54,7 +54,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from biip import ParseError
+from biip import ParseConfig, ParseError
 from biip.checksums import gs1_standard_check_digit
 from biip.gs1_prefixes import GS1CompanyPrefix, GS1Prefix
 
@@ -89,13 +89,19 @@ class Gln:
     """Check digit used to check if the GLN as a whole is valid."""
 
     @classmethod
-    def parse(cls, value: str) -> Gln:
+    def parse(
+        cls,
+        value: str,
+        *,
+        config: ParseConfig | None = None,  # noqa: ARG003
+    ) -> Gln:
         """Parse the given value into a [`Gln`][biip.gln.Gln] object.
 
         The checksum is guaranteed to be valid if a GLN object is returned.
 
         Args:
             value: The value to parse.
+            config: Configuration options for parsing.
 
         Returns:
             GLN data structure with the successfully extracted data.

--- a/src/biip/sscc.py
+++ b/src/biip/sscc.py
@@ -42,7 +42,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from biip import ParseError
+from biip import ParseConfig, ParseError
 from biip.checksums import gs1_standard_check_digit
 from biip.gs1_prefixes import GS1CompanyPrefix, GS1Prefix
 
@@ -80,13 +80,19 @@ class Sscc:
     """Check digit used to check if the SSCC as a whole is valid."""
 
     @classmethod
-    def parse(cls, value: str) -> Sscc:
+    def parse(
+        cls,
+        value: str,
+        *,
+        config: ParseConfig | None = None,  # noqa: ARG003
+    ) -> Sscc:
         """Parse the given value into a `Sscc` object.
 
         The checksum is guaranteed to be valid if an SSCC object is returned.
 
         Args:
             value: The value to parse.
+            config: Configuration options for parsing.
 
         Returns:
             SSCC data structure with the successfully extracted data.

--- a/src/biip/upc.py
+++ b/src/biip/upc.py
@@ -64,7 +64,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from enum import Enum
 
-from biip import EncodeError, ParseError
+from biip import EncodeError, ParseConfig, ParseError
 from biip.checksums import gs1_standard_check_digit
 
 
@@ -109,13 +109,19 @@ class Upc:
     """
 
     @classmethod
-    def parse(cls, value: str) -> Upc:
+    def parse(
+        cls,
+        value: str,
+        *,
+        config: ParseConfig | None = None,  # noqa: ARG003
+    ) -> Upc:
         """Parse the given value into a [`Upc`][biip.upc.Upc] object.
 
         The checksum is guaranteed to be valid if an UPC object is returned.
 
         Args:
             value: The value to parse.
+            config: Configuration options for parsing.
 
         Returns:
             UPC data structure with the successfully extracted data.

--- a/tests/gs1_messages/test_messages.py
+++ b/tests/gs1_messages/test_messages.py
@@ -4,7 +4,7 @@ from decimal import Decimal
 
 import pytest
 
-from biip import ParseError
+from biip import ParseConfig, ParseError
 from biip.gs1_application_identifiers import GS1ApplicationIdentifier
 from biip.gs1_messages import GS1ElementString, GS1Message
 from biip.gs1_prefixes import GS1CompanyPrefix, GS1Prefix
@@ -109,7 +109,10 @@ def test_parse_with_separator_char(
     value: str, separator_chars: Iterable[str], expected_hri: str
 ) -> None:
     assert (
-        GS1Message.parse(value, separator_chars=separator_chars).as_hri()
+        GS1Message.parse(
+            value,
+            config=ParseConfig(separator_chars=separator_chars),
+        ).as_hri()
         == expected_hri
     )
 
@@ -122,7 +125,10 @@ def test_parse_with_too_long_separator_char_fails() -> None:
             r"got \['--'\].$"
         ),
     ):
-        GS1Message.parse("10222--15210526", separator_chars=["--"])
+        GS1Message.parse(
+            "10222--15210526",
+            config=ParseConfig(separator_chars=["--"]),
+        )
 
 
 @pytest.mark.parametrize(
@@ -234,7 +240,7 @@ def test_parse_hri(value: str, expected: GS1Message) -> None:
 def test_parse_hri_with_gtin_with_variable_weight() -> None:
     result = GS1Message.parse_hri(
         "(01)02302148210869",
-        rcn_region=RcnRegion.NORWAY,
+        config=ParseConfig(rcn_region=RcnRegion.NORWAY),
     )
 
     gs1_gtin = result.get(ai="01")

--- a/tests/rcn/test_rcn.py
+++ b/tests/rcn/test_rcn.py
@@ -1,5 +1,6 @@
 import pytest
 
+from biip import ParseConfig
 from biip.gtin import Gtin, GtinFormat
 from biip.rcn import Rcn, RcnRegion, RcnUsage
 
@@ -23,7 +24,7 @@ from biip.rcn import Rcn, RcnRegion, RcnUsage
 def test_gtin_parse_may_return_rcn_instance(
     value: str, gtin_format: GtinFormat, rcn_usage: RcnUsage
 ) -> None:
-    rcn = Gtin.parse(value, rcn_region=RcnRegion.SWEDEN)
+    rcn = Gtin.parse(value, config=ParseConfig(rcn_region=RcnRegion.SWEDEN))
 
     assert isinstance(rcn, Rcn)
     assert rcn.format == gtin_format
@@ -35,7 +36,7 @@ def test_gtin_parse_may_return_rcn_instance(
 
 
 def test_rcn_without_specified_region() -> None:
-    rcn = Gtin.parse("2991111111113", rcn_region=None)
+    rcn = Gtin.parse("2991111111113", config=ParseConfig(rcn_region=None))
 
     assert isinstance(rcn, Rcn)
     assert rcn.format == GtinFormat.GTIN_13
@@ -48,7 +49,7 @@ def test_rcn_without_specified_region() -> None:
 
 def test_gtin_14_with_rcn_prefix_is_not_an_rcn() -> None:
     # The value below is a GTIN-14 composed of packaging level 1 and a valid RCN-13.
-    gtin = Gtin.parse("12991111111110", rcn_region=None)
+    gtin = Gtin.parse("12991111111110", config=ParseConfig(rcn_region=None))
 
     assert isinstance(gtin, Gtin)
     assert not isinstance(gtin, Rcn)
@@ -72,7 +73,7 @@ def test_gtin_14_with_rcn_prefix_is_not_an_rcn() -> None:
 def test_rcn_region_can_be_specified_as_string(
     value: str, rcn_region: RcnRegion
 ) -> None:
-    rcn = Gtin.parse("0211111111114", rcn_region=value)
+    rcn = Gtin.parse("0211111111114", config=ParseConfig(rcn_region=value))
 
     assert isinstance(rcn, Rcn)
     assert rcn.region == rcn_region
@@ -83,7 +84,7 @@ def test_fails_when_rcn_region_is_unknown_string() -> None:
         ValueError,
         match=r"^'foo' is not a valid RcnRegion$",
     ):
-        Gtin.parse("2311111112345", rcn_region="foo")
+        Gtin.parse("2311111112345", config=ParseConfig(rcn_region="foo"))
 
 
 def test_rcn_usage_repr() -> None:

--- a/tests/rcn/test_rules.py
+++ b/tests/rcn/test_rules.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 import pytest
 from moneyed import Money
 
-from biip import ParseError
+from biip import ParseConfig, ParseError
 from biip.gs1_prefixes import GS1Prefix
 from biip.gtin import Gtin, GtinFormat
 from biip.rcn import Rcn, RcnRegion, RcnUsage
@@ -45,7 +45,7 @@ def test_region_baltics(
     # References:
     #   https://gs1lv.org/img/upload/ENG.Variable%20measure_in_Latvia.pdf
 
-    rcn = Gtin.parse(value, rcn_region=rcn_region)
+    rcn = Gtin.parse(value, config=ParseConfig(rcn_region=rcn_region))
 
     assert isinstance(rcn, Rcn)
     assert rcn.region == rcn_region
@@ -77,7 +77,7 @@ def test_region_denmark(
     #   https://www.gs1.dk/om-gs1/overblik-over-gs1-standarder/gtin-13-pris
     #   https://www.gs1.dk/om-gs1/overblik-over-gs1-standarder/gtin-13-vaegt
 
-    rcn = Gtin.parse(value, rcn_region=RcnRegion.DENMARK)
+    rcn = Gtin.parse(value, config=ParseConfig(rcn_region=RcnRegion.DENMARK))
 
     assert isinstance(rcn, Rcn)
     assert rcn.region == RcnRegion.DENMARK
@@ -104,7 +104,7 @@ def test_region_finland(
     # References:
     #   https://gs1.fi/en/instructions/gs1-company-prefix/how-identify-product-gtin
 
-    rcn = Gtin.parse(value, rcn_region=RcnRegion.FINLAND)
+    rcn = Gtin.parse(value, config=ParseConfig(rcn_region=RcnRegion.FINLAND))
 
     assert isinstance(rcn, Rcn)
     assert rcn.region == RcnRegion.FINLAND
@@ -142,7 +142,7 @@ def test_region_germany(
     #   https://www.gs1-germany.de/fileadmin/gs1/fachpublikationen/globale-artikelnummer-gtin-in-der-anwendung.pdf
     #   https://san.gs1-germany.de/SAN-4-Konzept
 
-    rcn = Gtin.parse(value, rcn_region=RcnRegion.GERMANY)
+    rcn = Gtin.parse(value, config=ParseConfig(rcn_region=RcnRegion.GERMANY))
 
     assert isinstance(rcn, Rcn)
     assert rcn.region == RcnRegion.GERMANY
@@ -157,7 +157,7 @@ def test_region_germany_fails_with_invalid_variable_measure_check_digit() -> Non
     # correct value is 9.
 
     with pytest.raises(ParseError) as exc_info:
-        Gtin.parse("2511118000120", rcn_region=RcnRegion.GERMANY)
+        Gtin.parse("2511118000120", config=ParseConfig(rcn_region=RcnRegion.GERMANY))
 
     assert str(exc_info.value) == (
         "Invalid check digit for variable measure value '00012' "
@@ -171,8 +171,10 @@ def test_region_germany_when_not_verifying_invalid_check_digit() -> None:
 
     rcn = Gtin.parse(
         "2511118000120",
-        rcn_region=RcnRegion.GERMANY,
-        rcn_verify_variable_measure=False,
+        config=ParseConfig(
+            rcn_region=RcnRegion.GERMANY,
+            rcn_verify_variable_measure=False,
+        ),
     )
 
     assert isinstance(rcn, Rcn)
@@ -208,7 +210,7 @@ def test_region_great_britain(
     # References:
     #   https://www.gs1uk.org/how-to-barcode-variable-measure-items
 
-    rcn = Gtin.parse(value, rcn_region=RcnRegion.GREAT_BRITAIN)
+    rcn = Gtin.parse(value, config=ParseConfig(rcn_region=RcnRegion.GREAT_BRITAIN))
 
     assert isinstance(rcn, Rcn)
     assert rcn.region == RcnRegion.GREAT_BRITAIN
@@ -221,7 +223,10 @@ def test_region_great_britain_fails_with_invalid_price_check_digit() -> None:
     # The digit 8 in the value below is the price check digit. The correct value is 9.
 
     with pytest.raises(ParseError) as exc_info:
-        Gtin.parse("2011122812349", rcn_region=RcnRegion.GREAT_BRITAIN)
+        Gtin.parse(
+            "2011122812349",
+            config=ParseConfig(rcn_region=RcnRegion.GREAT_BRITAIN),
+        )
 
     assert str(exc_info.value) == (
         "Invalid check digit for variable measure value '1234' in RCN '2011122812349': "
@@ -234,8 +239,10 @@ def test_region_great_britain_when_not_verifying_invalid_check_digit() -> None:
 
     rcn = Gtin.parse(
         "2011122812349",
-        rcn_region=RcnRegion.GREAT_BRITAIN,
-        rcn_verify_variable_measure=False,
+        config=ParseConfig(
+            rcn_region=RcnRegion.GREAT_BRITAIN,
+            rcn_verify_variable_measure=False,
+        ),
     )
 
     assert isinstance(rcn, Rcn)
@@ -269,7 +276,7 @@ def test_region_norway(
 ) -> None:
     # References: TODO: Find specification.
 
-    rcn = Gtin.parse(value, rcn_region=RcnRegion.NORWAY)
+    rcn = Gtin.parse(value, config=ParseConfig(rcn_region=RcnRegion.NORWAY))
 
     assert isinstance(rcn, Rcn)
     assert rcn.region == RcnRegion.NORWAY
@@ -299,7 +306,7 @@ def test_region_sweden(
     # References:
     #   https://www.gs1.se/en/our-standards/Identify/variable-weight-number1/
 
-    rcn = Gtin.parse(value, rcn_region=RcnRegion.SWEDEN)
+    rcn = Gtin.parse(value, config=ParseConfig(rcn_region=RcnRegion.SWEDEN))
 
     assert isinstance(rcn, Rcn)
     assert rcn.region == RcnRegion.SWEDEN

--- a/tests/rcn/test_without_variable_measure.py
+++ b/tests/rcn/test_without_variable_measure.py
@@ -1,6 +1,6 @@
 import pytest
 
-from biip import EncodeError
+from biip import EncodeError, ParseConfig
 from biip.checksums import gs1_standard_check_digit
 from biip.gtin import Gtin
 from biip.rcn import Rcn, RcnRegion
@@ -25,7 +25,7 @@ from biip.rcn import Rcn, RcnRegion
 def test_without_variable_measure_strips_variable_parts(
     rcn_region: RcnRegion, value: str, expected: str
 ) -> None:
-    original_rcn = Gtin.parse(value, rcn_region=rcn_region)
+    original_rcn = Gtin.parse(value, config=ParseConfig(rcn_region=rcn_region))
     assert isinstance(original_rcn, Rcn)
 
     stripped_rcn = original_rcn.without_variable_measure()
@@ -82,7 +82,7 @@ def test_without_variable_measure_keeps_nonvariable_rcn_unchanged(
     for prefix in nonvariable_prefixes:
         payload = f"{prefix}1111111111"
         value = f"{payload}{gs1_standard_check_digit(payload)}"
-        original_rcn = Gtin.parse(value, rcn_region=rcn_region)
+        original_rcn = Gtin.parse(value, config=ParseConfig(rcn_region=rcn_region))
         assert isinstance(original_rcn, Rcn)
 
         stripped_rcn = original_rcn.without_variable_measure()
@@ -104,7 +104,7 @@ def test_without_variable_measure_keeps_nonvariable_rcn_unchanged(
 def test_without_variable_measure_keeps_company_rcn_unchanged(
     rcn_region: RcnRegion, value: str
 ) -> None:
-    original_rcn = Gtin.parse(value, rcn_region=rcn_region)
+    original_rcn = Gtin.parse(value, config=ParseConfig(rcn_region=rcn_region))
     assert isinstance(original_rcn, Rcn)
 
     stripped_rcn = original_rcn.without_variable_measure()
@@ -136,7 +136,7 @@ def test_without_variable_measure_keeps_gtin_unchanged(value: str) -> None:
 
 
 def test_without_variable_measure_fails_if_rules_are_unknown() -> None:
-    rcn = Gtin.parse("2302148210869", rcn_region=None)
+    rcn = Gtin.parse("2302148210869", config=ParseConfig(rcn_region=None))
     assert isinstance(rcn, Rcn)
 
     with pytest.raises(EncodeError) as exc_info:

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -3,7 +3,7 @@ from decimal import Decimal
 
 import pytest
 
-from biip import ParseResult, parse
+from biip import ParseConfig, ParseResult, parse
 from biip.gs1_application_identifiers import GS1ApplicationIdentifier
 from biip.gs1_messages import GS1ElementString, GS1Message
 from biip.gs1_prefixes import GS1CompanyPrefix, GS1Prefix
@@ -646,8 +646,10 @@ def test_parse_rcn_with_ignored_invalid_check_digit() -> None:
 
     result = parse(
         "]C10102824040005133",
-        rcn_region=RcnRegion.GERMANY,
-        rcn_verify_variable_measure=False,
+        config=ParseConfig(
+            rcn_region=RcnRegion.GERMANY,
+            rcn_verify_variable_measure=False,
+        ),
     )
 
     assert result == ParseResult(
@@ -712,7 +714,10 @@ def test_parse_strips_symbology_identifier() -> None:
 
 
 def test_parse_with_separator_char() -> None:
-    result = parse("101313|15210526", separator_chars=["|"])
+    result = parse(
+        "101313|15210526",
+        config=ParseConfig(separator_chars=["|"]),
+    )
 
     assert result.gs1_message is not None
     assert result.gs1_message.as_hri() == "(10)1313(15)210526"


### PR DESCRIPTION
Pass the config object to all parsers instead of passing around a growing set of keyword arguments.

Breaking change