### PR TITLE
Add config option to disable date validation in GS1 messages

### DIFF
--- a/src/biip/_config.py
+++ b/src/biip/_config.py
@@ -17,6 +17,17 @@ class ParseConfig:
     some of its the behavior by setting these options.
     """
 
+    gs1_message_verify_date: bool = True
+    """Whether to verify that the date in a GS1 message is valid.
+
+    According to the GS1 General Specification, dates are required to contain a
+    valid year and month. Only the day of month can be left as zeros, which
+    should be interpreted as the last day of the month.
+
+    Some barcodes include a GS1 element string with all zero dates, requiring
+    this check to be disabled.
+    """
+
     rcn_region: RcnRegion | str | None = None
     """The geographical region to use when parsing RCNs.
 

--- a/src/biip/gs1_messages/_element_strings.py
+++ b/src/biip/gs1_messages/_element_strings.py
@@ -184,7 +184,7 @@ class GS1ElementString:
         element._set_gln(config=config)
         element._set_gtin(config=config)
         element._set_sscc(config=config)
-        element._set_date_and_datetime()
+        element._set_date_and_datetime(config=config)
         element._set_decimal()
 
         return element
@@ -222,7 +222,7 @@ class GS1ElementString:
             self.sscc = None
             self.sscc_error = str(exc)
 
-    def _set_date_and_datetime(self) -> None:
+    def _set_date_and_datetime(self, *, config: ParseConfig) -> None:
         if self.ai.ai not in (
             "11",
             "12",
@@ -244,6 +244,8 @@ class GS1ElementString:
         try:
             self.date, self.datetime = _parse_date_and_datetime(self.value)
         except ValueError as exc:
+            if not config.gs1_message_verify_date:
+                return
             msg = f"Failed to parse GS1 AI {self.ai} date/time from {self.value!r}."
             raise ParseError(msg) from exc
 

--- a/tests/gs1_messages/test_messages.py
+++ b/tests/gs1_messages/test_messages.py
@@ -117,6 +117,35 @@ def test_parse_with_separator_char(
     )
 
 
+@pytest.mark.parametrize(
+    ("value", "config", "expected"),
+    [
+        (
+            # Invalid date "000000"
+            "15000000",
+            ParseConfig(gs1_message_verify_date=False),
+            GS1Message(
+                value="15000000",
+                element_strings=[
+                    GS1ElementString(
+                        ai=GS1ApplicationIdentifier.extract("15"),
+                        value="000000",
+                        pattern_groups=["000000"],
+                        date=None,
+                    )
+                ],
+            ),
+        ),
+    ],
+)
+def test_parse_with_invalid_element_values(
+    value: str,
+    config: ParseConfig,
+    expected: GS1Message,
+) -> None:
+    assert GS1Message.parse(value, config=config) == expected
+
+
 def test_parse_with_too_long_separator_char_fails() -> None:
     with pytest.raises(
         ValueError,


### PR DESCRIPTION
Fixes #247