### PR TITLE
Support GS1 Web URIs

### DIFF
--- a/docs/api/gs1_web_uris.md
+++ b/docs/api/gs1_web_uris.md
@@ -1,0 +1,3 @@
+# `biip.gs1_web_uris`
+
+::: biip.gs1_web_uris

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,6 +124,23 @@ including
 - [x] Parse Human Readable Interpretation (HRI) strings.
 - [x] Easy lookup of parsed Element Strings by Application Identifier (AI)
       prefix and part of AI's data title.
+- [x] Encode as GS1 Web URIs.
+
+### GS1 Web URIs
+
+GS1 Web URIs are used to encode the same information as GS1 messages, but as the
+path and query parameters of an URL. The URL can point to any domain. This means
+that barcodes containing GS1 Web URIs can be used both in the supply chain and
+for consumers to look up product information. GS1 Web URIs are used in the
+[GS1 DataMatrix](https://en.wikipedia.org/wiki/Data_Matrix) and
+[GS1 QR Code](https://en.wikipedia.org/wiki/QR_code)
+barcode symbologies.
+
+- [x] Everything supported for GS1 messages are also supported for GS1 Web URIs.
+- [x] Parse GS1 Web URIs, both canonical and non-canonical URIs.
+- [x] Encode GS1 Web URIs, both canonical and with custom domains, path
+      prefixes, and with short names instead of AIs for the fields encoded in the path.
+- [x] Encode as GS1 messages.
 
 ### GLN (Global Location Number)
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -552,6 +552,130 @@ we also need to tell Biip what character to expect by creating a
 
 Once again, all three element strings was successfully extracted.
 
+## GS1 Web URIs
+
+In an effort to make a single barcode that is useful both in the supply chain
+and for consumers wanting to learn more about the product they've purchased, GS1
+has developed the GS1 Web URI standard.
+
+GS1 Web URIs are HTTP URIs that can contain any domain name and any path prefix,
+and then encodes the element strings as path segments and query parameters in a
+standardized way.
+
+Let's assume that an imaginary manufacturer named Example Inc. wants to create a
+barcode for a product with GTIN `07032069804988`. The URI should link to their
+product information page. The barcode should also encode the batch number `0329`
+and the expiration date `2021-05-26` for easy tracking of the items through the
+supply chain. Using the GS1 Web URI specification, they create the following URI:
+
+```
+https://www.example.com/products/gtin/07032069804988?10=0329&15=210526
+```
+
+They put this in a GS1 QR code or a GS1 DataMatrix barcode, and print it on the
+product.
+
+When a consumer scans the barcode, they are taken to the product page. When the supply chain scans this barcode and use Biip to parse it, they get the following result:
+
+```python
+>>> result = biip.parse("https://www.example.com/products/gtin/07032069804988?10=0329&15=210526")
+>>> print(result)
+ParseResult(
+    value='https://www.example.com/products/gtin/07032069804988?10=0329&15=210526',
+    gtin=Gtin(
+        value='07032069804988',
+        format=GtinFormat.GTIN_13,
+        prefix=GS1Prefix(value='703', usage='GS1 Norway'),
+        company_prefix=GS1CompanyPrefix(value='703206'),
+        payload='703206980498',
+        check_digit=8
+    ),
+    gs1_web_uri=GS1WebURI(
+        value='https://www.example.com/products/gtin/07032069804988?10=0329&15=210526',
+        element_strings=[
+            GS1ElementString(
+                ai=GS1ApplicationIdentifier(
+                    ai='01',
+                    description='Global Trade Item Number (GTIN)',
+                    data_title='GTIN',
+                    separator_required=False,
+                    format='N2+N14'
+                ),
+                value='07032069804988',
+                pattern_groups=['07032069804988'],
+                gtin=Gtin(
+                    value='07032069804988',
+                    format=GtinFormat.GTIN_13,
+                    prefix=GS1Prefix(value='703', usage='GS1 Norway'),
+                    company_prefix=GS1CompanyPrefix(value='703206'),
+                    payload='703206980498',
+                    check_digit=8
+                )
+            ),
+            GS1ElementString(
+                ai=GS1ApplicationIdentifier(
+                    ai='10',
+                    description='Batch or lot number',
+                    data_title='BATCH/LOT',
+                    separator_required=True,
+                    format='N2+X..20'
+                ),
+                value='0329',
+                pattern_groups=['0329']
+            ),
+            GS1ElementString(
+                ai=GS1ApplicationIdentifier(
+                    ai='15',
+                    description='Best before date (YYMMDD)',
+                    data_title='BEST BEFORE or BEST BY',
+                    separator_required=False,
+                    format='N2+N6'
+                ),
+                value='210526',
+                pattern_groups=['210526'],
+                date=datetime.date(2021, 5, 26)
+            )
+        ]
+    )
+)
+```
+
+As you can see, Biip has extracted the GTIN, batch number and expiration date,
+just like we're used to with traditional GS1 message barcodes.
+
+You can also use Biip to convert the result to a canonical GS1 Web URI:
+
+```python
+>>> result.gs1_web_uri.as_canonical_uri()
+'https://id.gs1.org/01/07032069804988/10/0329?15=210526'
+```
+
+Or to convert it to a GS1 message and print the equivalent HRI representation:
+
+```python
+>>> message = result.gs1_web_uri.as_gs1_message()
+>>> message.as_hri()
+'(01)07032069804988(10)0329(15)210526'
+```
+
+If you have an existing GS1 message barcode and want to convert it to a GS1 Web
+URI, Biip can also be helpful:
+
+```python
+>>> web_uri = message.as_gs1_web_uri()
+>>> web_uri.as_uri(
+...    domain="another.example.net",
+...    prefix="database",
+... )
+'https://another.example.net/database/01/07032069804988/10/0329?15=210526'
+>>> web_uri.as_uri(
+...    domain="another.example.net",
+...    prefix="database",
+...    short_names=True,
+... )
+'https://another.example.net/database/gtin/07032069804988/lot/0329?15=210526'
+```
+
 ## Deep dive
 
 This quickstart guide covers the surface of Biip and should get you

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -18,6 +18,7 @@ nav:
       - api/gs1_element_strings.md
       - api/gs1_messages.md
       - api/gs1_prefixes.md
+      - api/gs1_web_uris.md
       - api/gtin.md
       - api/rcn.md
       - api/sscc.md

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -61,6 +61,8 @@ def parse(
             in GS1Symbology.with_gs1_messages()
         ):
             queue.append((_parse_gs1_message, value))
+        if result.symbology_identifier.gs1_symbology in GS1Symbology.with_gs1_web_uri():
+            queue.append((_parse_gs1_web_uri, value))
     elif value.startswith("http"):
         queue.append((_parse_gs1_web_uri, value))
     if not queue:

--- a/src/biip/_parser.py
+++ b/src/biip/_parser.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any
 
 from biip import ParseConfig, ParseError
 from biip.gs1_messages import GS1Message
+from biip.gs1_web_uris import GS1WebURI
 from biip.gtin import Gtin, GtinFormat
 from biip.sscc import Sscc
 from biip.symbology import GS1Symbology, SymbologyIdentifier
@@ -15,6 +16,8 @@ from biip.upc import Upc
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+
+    from biip.gs1_element_strings import GS1ElementStrings
 
 
 def parse(
@@ -58,6 +61,8 @@ def parse(
             in GS1Symbology.with_gs1_messages()
         ):
             queue.append((_parse_gs1_message, value))
+    elif value.startswith("http"):
+        queue.append((_parse_gs1_web_uri, value))
     if not queue:
         # If we're not able to select a subset based on Symbology Identifiers,
         # run all parsers on the full value.
@@ -119,6 +124,15 @@ class ParseResult:
     If parsing as a GS1 Message was attempted and failed.
     """
 
+    gs1_web_uri: GS1WebURI | None = None
+    """The extracted [GS1 Web URI][biip.gs1_web_uris.GS1WebURI], if any."""
+
+    gs1_web_uri_error: str | None = None
+    """The GS1 Web URI parse error.
+
+    If parsing as a GS1 Web URI was attempted and failed.
+    """
+
     def __rich_repr__(self) -> Iterator[tuple[str, Any] | tuple[str, Any, Any]]:
         # Skip printing fields with default values
         yield "value", self.value
@@ -131,6 +145,8 @@ class ParseResult:
         yield "sscc_error", self.sscc_error, None
         yield "gs1_message", self.gs1_message, None
         yield "gs1_message_error", self.gs1_message_error, None
+        yield "gs1_web_uri", self.gs1_web_uri, None
+        yield "gs1_web_uri_error", self.gs1_web_uri_error, None
 
 
 ParseQueue = list[tuple["Parser", str]]
@@ -211,12 +227,38 @@ def _parse_gs1_message(
         result.gs1_message = None
         result.gs1_message_error = str(exc)
     else:
-        # If the GS1 Message contains an SSCC, set SSCC on the top-level result.
-        ai_00 = result.gs1_message.element_strings.get(ai="00")
-        if ai_00 is not None:
-            queue.append((_parse_sscc, ai_00.value))
+        _promote_gs1_elements(result.gs1_message.element_strings, queue)
 
-        # If the GS1 Message contains an GTIN, set GTIN on the top-level result.
-        ai_01 = result.gs1_message.element_strings.get(ai="01")
-        if ai_01 is not None:
-            queue.append((_parse_gtin, ai_01.value))
+
+def _parse_gs1_web_uri(
+    value: str,
+    config: ParseConfig,
+    queue: ParseQueue,
+    result: ParseResult,
+) -> None:
+    if result.gs1_web_uri is not None:
+        return  # pragma: no cover
+
+    try:
+        result.gs1_web_uri = GS1WebURI.parse(value, config=config)
+        result.gs1_web_uri_error = None
+    except ParseError as exc:
+        result.gs1_web_uri = None
+        result.gs1_web_uri_error = str(exc)
+    else:
+        _promote_gs1_elements(result.gs1_web_uri.element_strings, queue)
+
+
+def _promote_gs1_elements(
+    gs1_element_strings: GS1ElementStrings,
+    queue: ParseQueue,
+) -> None:
+    # If the GS1 Message contains an SSCC, set SSCC on the top-level result.
+    ai_00 = gs1_element_strings.get(ai="00")
+    if ai_00 is not None:
+        queue.append((_parse_sscc, ai_00.value))
+
+    # If the GS1 Message contains an GTIN, set GTIN on the top-level result.
+    ai_01 = gs1_element_strings.get(ai="01")
+    if ai_01 is not None:
+        queue.append((_parse_gtin, ai_01.value))

--- a/src/biip/gs1_messages.py
+++ b/src/biip/gs1_messages.py
@@ -115,11 +115,15 @@ from __future__ import annotations
 import re
 from dataclasses import dataclass
 from itertools import chain
+from typing import TYPE_CHECKING
 
 from biip import ParseError
 from biip._parser import ParseConfig
 from biip.gs1_application_identifiers import _GS1_APPLICATION_IDENTIFIERS
 from biip.gs1_element_strings import GS1ElementString, GS1ElementStrings
+
+if TYPE_CHECKING:
+    from biip.gs1_web_uris import GS1WebURI
 
 
 @dataclass
@@ -258,3 +262,9 @@ class GS1Message:
             A human-readable string where the AIs are wrapped in parenthesis.
         """
         return "".join(es.as_hri() for es in self.element_strings)
+
+    def as_gs1_web_uri(self) -> GS1WebURI:
+        """Convert to a GS1 Web URI."""
+        from biip.gs1_web_uris import GS1WebURI
+
+        return GS1WebURI.from_element_strings(self.element_strings)

--- a/src/biip/gs1_web_uris.py
+++ b/src/biip/gs1_web_uris.py
@@ -131,6 +131,8 @@ from biip.gs1_element_strings import GS1ElementString, GS1ElementStrings
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
+    from biip.gs1_messages import GS1Message
+
 
 @dataclass
 class GS1WebURI:
@@ -293,6 +295,12 @@ class GS1WebURI:
                 None,
             ]
         )
+
+    def as_gs1_message(self) -> GS1Message:
+        """Converts the GS1 Web URI to a GS1 Message."""
+        from biip.gs1_messages import GS1Message
+
+        return GS1Message.from_element_strings(self.element_strings)
 
 
 def _get_pairs(iterable: Iterable[str]) -> Iterator[tuple[str, str]]:

--- a/src/biip/gs1_web_uris.py
+++ b/src/biip/gs1_web_uris.py
@@ -1,0 +1,418 @@
+"""Support for GS1 Web URIs.
+
+GS1 Web URIs are HTTP(S) URIs pointing to any hostname, optionally with a path
+prefix, where GS1 element strings are encoded in the path and query parameters.
+
+Examples of GS1 Web URIs:
+
+- `https://id.gs1.org/gtin/614141123452/lot/ABC1/ser/12345?exp=180426`
+- `https://id.gs1.org/gtin/614141123452?3103=000195`
+- `https://id.gs1.org/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123`
+
+This makes it possible to use GS1 Web URIs encoded in 2D barcodes both in
+supply chain and logistics applications, as well as for consumers to look up
+product information.
+
+References:
+    https://www.gs1.org/standards/Digital-Link/1-0
+
+## Example
+
+If you only want to parse GS1 Web URIs, you can import the GS1 Web URI parser
+directly instead of using [`biip.parse()`][biip.parse].
+
+    >>> from biip.gs1_web_uris import GS1WebURI
+
+If the parsing succeeds, it returns a [`GS1WebURI`][biip.gs1_web_uris.GS1WebURI] object.
+
+    >>> web_uri = GS1WebURI.parse("https://id.gs1.org/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123")
+
+In this case, the URI is parsed into the SSCC of a shipping container, the GTIN
+of the product within the shipping container, the number of item within, and the
+batch number.
+
+    >>> pprint(web_uri.element_strings)
+    [
+        GS1ElementString(
+            ai=GS1ApplicationIdentifier(
+                ai='00',
+                description='Serial Shipping Container Code (SSCC)',
+                data_title='SSCC',
+                separator_required=False,
+                format='N2+N18'
+            ),
+            value='106141412345678908',
+            pattern_groups=[
+                '106141412345678908'
+            ],
+            sscc=Sscc(
+                value='106141412345678908',
+                prefix=GS1Prefix(
+                    value='061',
+                    usage='GS1 US'
+                ),
+                company_prefix=GS1CompanyPrefix(
+                    value='0614141'
+                ),
+                extension_digit=1,
+                payload='10614141234567890',
+                check_digit=8
+            )
+        ),
+        GS1ElementString(
+            ai=GS1ApplicationIdentifier(
+                ai='02',
+                description='Global Trade Item Number (GTIN) of contained trade items',
+                data_title='CONTENT',
+                separator_required=False,
+                format='N2+N14'
+            ),
+            value='00614141123452',
+            pattern_groups=[
+                '00614141123452'
+            ],
+            gtin=Gtin(
+                value='00614141123452',
+                format=GtinFormat.GTIN_12,
+                prefix=GS1Prefix(
+                    value='061',
+                    usage='GS1 US'
+                ),
+                company_prefix=GS1CompanyPrefix(
+                    value='0614141'
+                ),
+                payload='61414112345',
+                check_digit=2
+            )
+        ),
+        GS1ElementString(
+            ai=GS1ApplicationIdentifier(
+                ai='37',
+                description='Count of trade items or trade item pieces contained in a logistic unit',
+                data_title='COUNT',
+                separator_required=True,
+                format='N2+N..8'
+            ),
+            value='25',
+            pattern_groups=[
+                '25'
+            ]
+        ),
+        GS1ElementString(
+            ai=GS1ApplicationIdentifier(
+                ai='10',
+                description='Batch or lot number',
+                data_title='BATCH/LOT',
+                separator_required=True,
+                format='N2+X..20'
+            ),
+            value='ABC123',
+            pattern_groups=[
+                'ABC123'
+            ]
+        )
+    ]
+"""  # noqa: E501
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+from urllib.parse import parse_qs, urlparse
+
+from biip import ParseConfig, ParseError
+from biip.gs1_application_identifiers import (
+    _GS1_APPLICATION_IDENTIFIERS,
+    GS1ApplicationIdentifier,
+)
+from biip.gs1_element_strings import GS1ElementString, GS1ElementStrings
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator
+
+
+@dataclass
+class GS1WebURI:
+    """A GS1 Web URI is a URI that contains GS1 Element Strings."""
+
+    value: str
+    """Raw unprocessed value."""
+
+    element_strings: GS1ElementStrings
+    """List of Element Strings found in the message."""
+
+    @classmethod
+    def parse(  # noqa: C901
+        cls,
+        value: str,
+        *,
+        config: ParseConfig | None = None,
+    ) -> GS1WebURI:
+        """Parse a string as a GS1 Web URI.
+
+        Args:
+            value: The string to parse.
+            config: The parse configuration.
+
+        Returns:
+            The parsed GS1 Web URI.
+
+        Raises:
+            ParseError: If the parsing fails.
+        """
+        if config is None:
+            config = ParseConfig()
+
+        parsed = urlparse(value)
+
+        match parsed.scheme:
+            case "https" | "http":
+                pass
+            case "":
+                msg = f"Expected URI, got {value!r}."
+                raise ParseError(msg)
+            case scheme:
+                msg = f"Expected URI scheme to be 'http' or 'https', got {scheme!r}."
+                raise ParseError(msg)
+
+        # Consume path prefix
+        path_parts = parsed.path.split("/")
+        while path_parts:
+            if path_parts[0] in _PRIMARY_IDENTIFIER_MAP:
+                break
+            path_parts.pop(0)
+
+        if not path_parts:
+            msg = f"Expected a primary identifier in the path, got '{parsed.path}'."
+            raise ParseError(msg)
+
+        if len(path_parts) % 2 != 0:
+            path = f"/{'/'.join(path_parts)}"
+            msg = f"Expected even number of path segments, got {path!r}."
+            raise ParseError(msg)
+
+        element_strings = GS1ElementStrings()
+        path_pairs = _get_pairs(path_parts)
+
+        # Extract exactly one primary identifier from path
+        (pi_key, pi_value) = next(path_pairs)
+        pi = _PRIMARY_IDENTIFIER_MAP[pi_key]
+        if pi.zfill_to_width:
+            pi_value = pi_value.zfill(pi.zfill_to_width)
+        element_strings.append(
+            GS1ElementString.extract(
+                f"{pi.ai.ai}{pi_value}",
+                config=config,
+            )
+        )
+
+        # Extract qualifiers from path
+        expected_qualifiers = list(pi.qualifiers)
+        for qualifier_key, qualifier_value in path_pairs:
+            qualifier = _get_qualifier(qualifier_key, expected_qualifiers)
+            element_strings.append(
+                GS1ElementString.extract(
+                    f"{qualifier.ai.ai}{qualifier_value}",
+                    config=config,
+                )
+            )
+
+        # Extract query string components
+        query_pairs = [
+            (key, vals[-1])  # If an AI is repeated, the last value is used.
+            for key, vals in parse_qs(parsed.query).items()
+        ]
+        for component_key, component_value in query_pairs:
+            ai = _GS1_APPLICATION_IDENTIFIERS.get(component_key)
+            if ai is None:
+                # Extra query parameters are ignored.
+                continue
+            element_strings.append(
+                GS1ElementString.extract(
+                    f"{ai.ai}{component_value}",
+                    config=config,
+                )
+            )
+
+        return cls(value=value, element_strings=element_strings)
+
+
+def _get_pairs(iterable: Iterable[str]) -> Iterator[tuple[str, str]]:
+    # Replace this function with itertools.batched(v, 2) when we require Python >= 3.12.
+    iterator = iter(iterable)
+    try:
+        while True:
+            yield next(iterator), next(iterator)
+    except StopIteration:
+        return
+
+
+def _get_qualifier(
+    qualifier_key: str,
+    expected_qualifiers: list[_Component],
+) -> _Component:
+    if not expected_qualifiers:
+        msg = f"Did not expect a qualifier, got {qualifier_key!r}."
+        raise ParseError(msg)
+    expected_qualifier_names = "/".join(
+        f"{eq.ai.ai}/{eq.short_name}" for eq in expected_qualifiers
+    )
+    while expected_qualifiers:
+        # Consume the expected qualifier, so that they can only be used
+        # once, and only in order.
+        qualifier = expected_qualifiers.pop(0)
+        if qualifier_key in (qualifier.ai.ai, qualifier.short_name):
+            return qualifier
+    msg = (
+        f"Expected one of {expected_qualifier_names} as qualifier, "
+        f"got {qualifier_key!r}."
+    )
+    raise ParseError(msg)
+
+
+@dataclass(frozen=True)
+class _Component:
+    ai: GS1ApplicationIdentifier
+    short_name: str
+    zfill_to_width: int | None = None
+    qualifiers: tuple[_Component, ...] = field(default_factory=tuple)
+
+
+_PRIMARY_IDENTIFIERS = [
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("01"),
+        short_name="gtin",
+        zfill_to_width=14,
+        qualifiers=(
+            _Component(
+                ai=GS1ApplicationIdentifier.extract("22"),
+                short_name="cpv",
+            ),
+            _Component(
+                ai=GS1ApplicationIdentifier.extract("10"),
+                short_name="lot",
+            ),
+            _Component(
+                ai=GS1ApplicationIdentifier.extract("21"),
+                short_name="ser",
+            ),
+        ),
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("8006"),
+        short_name="itip",
+        qualifiers=(
+            _Component(
+                ai=GS1ApplicationIdentifier.extract("22"),
+                short_name="cpv",
+            ),
+            _Component(
+                ai=GS1ApplicationIdentifier.extract("10"),
+                short_name="lot",
+            ),
+            _Component(
+                ai=GS1ApplicationIdentifier.extract("21"),
+                short_name="ser",
+            ),
+        ),
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("8013"),
+        short_name="gmn",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("8010"),
+        short_name="cpid",
+        qualifiers=(
+            _Component(
+                ai=GS1ApplicationIdentifier.extract("8011"),
+                short_name="cpsn",
+            ),
+        ),
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("410"),
+        short_name="shipTo",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("411"),
+        short_name="billTo",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("412"),
+        short_name="purchasedFrom",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("413"),
+        short_name="shipFor",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("414"),
+        short_name="gln",
+        qualifiers=(
+            _Component(
+                ai=GS1ApplicationIdentifier.extract("254"),
+                short_name="glnx",
+            ),
+        ),
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("415"),
+        short_name="payTo",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("416"),
+        short_name="glnProd",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("8017"),
+        short_name="gsrnp",
+        qualifiers=(
+            _Component(
+                ai=GS1ApplicationIdentifier.extract("8019"),
+                short_name="srin",
+            ),
+        ),
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("8018"),
+        short_name="gsrn",
+        qualifiers=(
+            _Component(
+                ai=GS1ApplicationIdentifier.extract("8019"),
+                short_name="srin",
+            ),
+        ),
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("255"),
+        short_name="gcn",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("00"),
+        short_name="sscc",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("253"),
+        short_name="gdti",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("401"),
+        short_name="ginc",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("402"),
+        short_name="gsin",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("8003"),
+        short_name="grai",
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("8004"),
+        short_name="giai",
+    ),
+]
+_PRIMARY_IDENTIFIER_MAP = {pi.short_name: pi for pi in _PRIMARY_IDENTIFIERS} | {
+    pi.ai.ai: pi for pi in _PRIMARY_IDENTIFIERS
+}

--- a/src/biip/symbology.py
+++ b/src/biip/symbology.py
@@ -207,6 +207,11 @@ class GS1Symbology(Enum):
         }
 
     @classmethod
+    def with_gs1_web_uri(cls) -> set[GS1Symbology]:
+        """Symbologies that may contain GS1 Web URIs."""
+        return {cls.GS1_DATAMATRIX, cls.GS1_QR_CODE}
+
+    @classmethod
     def with_gtin(cls) -> set[GS1Symbology]:
         """Symbologies that may contain GTINs."""
         return {cls.EAN_13, cls.EAN_13_WITH_ADD_ON, cls.EAN_8, cls.ITF_14}

--- a/tests/test_gs1_messages.py
+++ b/tests/test_gs1_messages.py
@@ -432,6 +432,19 @@ def test_as_hri(value: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            "010703206980498815210526100329",
+            "https://id.gs1.org/01/07032069804988/10/0329?15=210526",
+        )
+    ],
+)
+def test_as_gs1_web_uri(value: str, expected: str) -> None:
+    assert GS1Message.parse(value).as_gs1_web_uri().value == expected
+
+
+@pytest.mark.parametrize(
     ("value", "ai", "expected"),
     [
         ("010703206980498815210526100329", "01", ["07032069804988"]),

--- a/tests/test_gs1_web_uris.py
+++ b/tests/test_gs1_web_uris.py
@@ -295,3 +295,70 @@ def test_parse_with_invalid_element_values(
 def test_parse_error(value: str, error: str) -> None:
     with pytest.raises(ParseError, match=error):
         GS1WebURI.parse(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "ai", "expected"),
+    [
+        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "01", ["00614141123452"]),
+        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "10", ["ABC123"]),
+    ],
+)
+def test_filter_element_strings_by_ai(value: str, ai: str, expected: list[str]) -> None:
+    matches = GS1WebURI.parse(value).element_strings.filter(ai=ai)
+
+    assert [element_string.value for element_string in matches] == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "data_title", "expected"),
+    [
+        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "GTIN", ["00614141123452"]),
+        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "BATCH", ["ABC123"]),
+    ],
+)
+def test_filter_element_strings_by_data_title(
+    value: str, data_title: str, expected: list[str]
+) -> None:
+    matches = GS1WebURI.parse(value).element_strings.filter(data_title=data_title)
+
+    assert [element_string.value for element_string in matches] == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "ai", "expected"),
+    [
+        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "01", "00614141123452"),
+        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "10", "ABC123"),
+        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "15", None),
+    ],
+)
+def test_get_element_strings_by_ai(value: str, ai: str, expected: str | None) -> None:
+    element_string = GS1WebURI.parse(value).element_strings.get(ai=ai)
+
+    if expected is None:
+        assert element_string is None
+    else:
+        assert element_string is not None
+        assert element_string.value == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "data_title", "expected"),
+    [
+        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "GTIN", "00614141123452"),
+        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "BATCH", "ABC123"),
+        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "LOT", "ABC123"),
+        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "BEST BY", None),
+    ],
+)
+def test_get_element_strings_by_data_title(
+    value: str, data_title: str, expected: str | None
+) -> None:
+    element_string = GS1WebURI.parse(value).element_strings.get(data_title=data_title)
+
+    if expected is None:
+        assert element_string is None
+    else:
+        assert element_string is not None
+        assert element_string.value == expected

--- a/tests/test_gs1_web_uris.py
+++ b/tests/test_gs1_web_uris.py
@@ -1,3 +1,5 @@
+import datetime as dt
+
 import pytest
 
 from biip import ParseConfig, ParseError
@@ -295,6 +297,76 @@ def test_parse_with_invalid_element_values(
 def test_parse_error(value: str, error: str) -> None:
     with pytest.raises(ParseError, match=error):
         GS1WebURI.parse(value)
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            GS1ElementStrings(
+                [
+                    GS1ElementString(
+                        ai=GS1ApplicationIdentifier.extract("01"),
+                        value="07032069804988",
+                        pattern_groups=["07032069804988"],
+                        gtin=Gtin(
+                            value="07032069804988",
+                            format=GtinFormat.GTIN_13,
+                            prefix=GS1Prefix(value="703", usage="GS1 Norway"),
+                            company_prefix=GS1CompanyPrefix(value="703206"),
+                            payload="703206980498",
+                            check_digit=8,
+                        ),
+                    ),
+                    GS1ElementString(
+                        ai=GS1ApplicationIdentifier.extract("15"),
+                        value="210526",
+                        pattern_groups=["210526"],
+                        date=dt.date(2021, 5, 26),
+                    ),
+                    GS1ElementString(
+                        ai=GS1ApplicationIdentifier.extract("10"),
+                        value="0329",
+                        pattern_groups=["0329"],
+                    ),
+                ]
+            ),
+            GS1WebURI(
+                value="https://id.gs1.org/01/07032069804988/10/0329?15=210526",
+                element_strings=GS1ElementStrings(
+                    [
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("01"),
+                            value="07032069804988",
+                            pattern_groups=["07032069804988"],
+                            gtin=Gtin(
+                                value="07032069804988",
+                                format=GtinFormat.GTIN_13,
+                                prefix=GS1Prefix(value="703", usage="GS1 Norway"),
+                                company_prefix=GS1CompanyPrefix(value="703206"),
+                                payload="703206980498",
+                                check_digit=8,
+                            ),
+                        ),
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("15"),
+                            value="210526",
+                            pattern_groups=["210526"],
+                            date=dt.date(2021, 5, 26),
+                        ),
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("10"),
+                            value="0329",
+                            pattern_groups=["0329"],
+                        ),
+                    ]
+                ),
+            ),
+        ),
+    ],
+)
+def test_from_element_strings(value: GS1ElementStrings, expected: GS1WebURI) -> None:
+    assert GS1WebURI.from_element_strings(value) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gs1_web_uris.py
+++ b/tests/test_gs1_web_uris.py
@@ -1,0 +1,297 @@
+import pytest
+
+from biip import ParseConfig, ParseError
+from biip.gs1_application_identifiers import GS1ApplicationIdentifier
+from biip.gs1_element_strings import GS1ElementString, GS1ElementStrings
+from biip.gs1_prefixes import GS1CompanyPrefix, GS1Prefix
+from biip.gs1_web_uris import GS1WebURI
+from biip.gtin import Gtin, GtinFormat
+from biip.sscc import Sscc
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            # GTIN-12 by AI number
+            "https://id.gs1.org/01/614141123452",
+            GS1WebURI(
+                value="https://id.gs1.org/01/614141123452",
+                element_strings=GS1ElementStrings(
+                    [
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("01"),
+                            value="00614141123452",
+                            pattern_groups=["00614141123452"],
+                            gtin=Gtin(
+                                value="00614141123452",
+                                format=GtinFormat.GTIN_12,
+                                prefix=GS1Prefix(value="061", usage="GS1 US"),
+                                company_prefix=GS1CompanyPrefix(value="0614141"),
+                                payload="61414112345",
+                                check_digit=2,
+                            ),
+                        ),
+                    ]
+                ),
+            ),
+        ),
+        (
+            # GTIN-12 with custom domain, path prefix, and AI alias
+            "https://example.com/foo/gtin/614141123452",
+            GS1WebURI(
+                value="https://example.com/foo/gtin/614141123452",
+                element_strings=GS1ElementStrings(
+                    [
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("01"),
+                            value="00614141123452",
+                            pattern_groups=["00614141123452"],
+                            gtin=Gtin(
+                                value="00614141123452",
+                                format=GtinFormat.GTIN_12,
+                                prefix=GS1Prefix(value="061", usage="GS1 US"),
+                                company_prefix=GS1CompanyPrefix(value="0614141"),
+                                payload="61414112345",
+                                check_digit=2,
+                            ),
+                        ),
+                    ]
+                ),
+            ),
+        ),
+        (
+            # GTIN-12 and batch/lot number by AI number
+            "https://id.gs1.org/01/614141123452/10/ABC123",
+            GS1WebURI(
+                value="https://id.gs1.org/01/614141123452/10/ABC123",
+                element_strings=GS1ElementStrings(
+                    [
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("01"),
+                            value="00614141123452",
+                            pattern_groups=["00614141123452"],
+                            gtin=Gtin(
+                                value="00614141123452",
+                                format=GtinFormat.GTIN_12,
+                                prefix=GS1Prefix(value="061", usage="GS1 US"),
+                                company_prefix=GS1CompanyPrefix(value="0614141"),
+                                payload="61414112345",
+                                check_digit=2,
+                            ),
+                        ),
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("10"),
+                            value="ABC123",
+                            pattern_groups=["ABC123"],
+                        ),
+                    ]
+                ),
+            ),
+        ),
+        (
+            # GTIN-12, CPV, and batch/lot number by AI alias
+            "https://id.gs1.org/gtin/614141123452/cpv/2A/lot/ABC123",
+            GS1WebURI(
+                value="https://id.gs1.org/gtin/614141123452/cpv/2A/lot/ABC123",
+                element_strings=GS1ElementStrings(
+                    [
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("01"),
+                            value="00614141123452",
+                            pattern_groups=["00614141123452"],
+                            gtin=Gtin(
+                                value="00614141123452",
+                                format=GtinFormat.GTIN_12,
+                                prefix=GS1Prefix(value="061", usage="GS1 US"),
+                                company_prefix=GS1CompanyPrefix(value="0614141"),
+                                payload="61414112345",
+                                check_digit=2,
+                            ),
+                        ),
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("22"),
+                            value="2A",
+                            pattern_groups=["2A"],
+                        ),
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("10"),
+                            value="ABC123",
+                            pattern_groups=["ABC123"],
+                        ),
+                    ]
+                ),
+            ),
+        ),
+        (
+            # GTIN-12 with extra query parameter that is ignored
+            "https://id.gs1.org/01/614141123452?foo=bar",
+            GS1WebURI(
+                value="https://id.gs1.org/01/614141123452?foo=bar",
+                element_strings=GS1ElementStrings(
+                    [
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("01"),
+                            value="00614141123452",
+                            pattern_groups=["00614141123452"],
+                            gtin=Gtin(
+                                value="00614141123452",
+                                format=GtinFormat.GTIN_12,
+                                prefix=GS1Prefix(value="061", usage="GS1 US"),
+                                company_prefix=GS1CompanyPrefix(value="0614141"),
+                                payload="61414112345",
+                                check_digit=2,
+                            ),
+                        ),
+                    ]
+                ),
+            ),
+        ),
+        (
+            # SSCC with content, count, and batch/lot number
+            "https://id.gs1.org/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123",
+            GS1WebURI(
+                value="https://id.gs1.org/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123",
+                element_strings=GS1ElementStrings(
+                    [
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("00"),
+                            value="106141412345678908",
+                            pattern_groups=["106141412345678908"],
+                            sscc=Sscc(
+                                value="106141412345678908",
+                                prefix=GS1Prefix(value="061", usage="GS1 US"),
+                                company_prefix=GS1CompanyPrefix(value="0614141"),
+                                extension_digit=1,
+                                payload="10614141234567890",
+                                check_digit=8,
+                            ),
+                        ),
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("02"),
+                            value="00614141123452",
+                            pattern_groups=["00614141123452"],
+                            gln=None,
+                            gln_error=None,
+                            gtin=Gtin(
+                                value="00614141123452",
+                                format=GtinFormat.GTIN_12,
+                                prefix=GS1Prefix(value="061", usage="GS1 US"),
+                                company_prefix=GS1CompanyPrefix(value="0614141"),
+                                payload="61414112345",
+                                check_digit=2,
+                                packaging_level=None,
+                            ),
+                        ),
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("37"),
+                            value="25",
+                            pattern_groups=["25"],
+                        ),
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("10"),
+                            value="ABC123",
+                            pattern_groups=["ABC123"],
+                        ),
+                    ]
+                ),
+            ),
+        ),
+    ],
+)
+def test_parse(value: str, expected: GS1WebURI) -> None:
+    assert GS1WebURI.parse(value) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "config", "expected"),
+    [
+        (
+            # Invalid date "000000"
+            "https://id.gs1.org/gtin/614141123452?15=000000",
+            ParseConfig(gs1_element_strings_verify_date=False),
+            GS1WebURI(
+                value="https://id.gs1.org/gtin/614141123452?15=000000",
+                element_strings=GS1ElementStrings(
+                    [
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("01"),
+                            value="00614141123452",
+                            pattern_groups=["00614141123452"],
+                            gtin=Gtin(
+                                value="00614141123452",
+                                format=GtinFormat.GTIN_12,
+                                prefix=GS1Prefix(value="061", usage="GS1 US"),
+                                company_prefix=GS1CompanyPrefix(value="0614141"),
+                                payload="61414112345",
+                                check_digit=2,
+                            ),
+                        ),
+                        GS1ElementString(
+                            ai=GS1ApplicationIdentifier.extract("15"),
+                            value="000000",
+                            pattern_groups=["000000"],
+                            date=None,
+                        ),
+                    ]
+                ),
+            ),
+        ),
+    ],
+)
+def test_parse_with_invalid_element_values(
+    value: str,
+    config: ParseConfig,
+    expected: GS1WebURI,
+) -> None:
+    assert GS1WebURI.parse(value, config=config) == expected
+
+
+@pytest.mark.parametrize(
+    ("value", "error"),
+    [
+        (
+            # Non-URI are not allowed
+            "614141123452",
+            r"^Expected URI, got '614141123452'.$",
+        ),
+        (
+            # Non-HTTP URIs are not allowed
+            "mailto:alice@example.com",
+            r"^Expected URI scheme to be 'http' or 'https', got 'mailto'.$",
+        ),
+        (
+            # A primary identifier in the path is required
+            "http://example.com/foo/123",
+            r"^Expected a primary identifier in the path, got '/foo/123'.$",
+        ),
+        (
+            # The path must contain an even number of segments
+            "https://example.com/foo/gtin/614141123452/123",
+            r"^Expected even number of path segments, got '/gtin/614141123452/123'.$",
+        ),
+        (
+            # "exp" is not a valid qualifier for GTIN
+            "https://id.gs1.org/gtin/614141123452/exp/20250324",
+            r"^Expected one of 22/cpv/10/lot/21/ser as qualifier, got 'exp'.$",
+        ),
+        (
+            # "cpv" is a valid qualifier, but not after "lot"
+            "https://id.gs1.org/gtin/614141123452/lot/ABC123/cpv/123456789",
+            r"^Expected one of 21/ser as qualifier, got 'cpv'.$",
+        ),
+        (
+            # "lot" is a valid qualifier, but not after "ser"
+            "https://id.gs1.org/gtin/01234567890128/ser/12345XYZ/lot/ABC123",
+            r"^Did not expect a qualifier, got 'lot'.$",
+        ),
+        (
+            # "lot" is not a valid qualifier for SSCC
+            "https://id.gs1.org/sscc/106141412345678908/lot/ABC123",
+            r"^Did not expect a qualifier, got 'lot'.$",
+        ),
+    ],
+)
+def test_parse_error(value: str, error: str) -> None:
+    with pytest.raises(ParseError, match=error):
+        GS1WebURI.parse(value)

--- a/tests/test_gs1_web_uris.py
+++ b/tests/test_gs1_web_uris.py
@@ -298,6 +298,31 @@ def test_parse_error(value: str, error: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            "https://example.com/01/614141123452",
+            "https://id.gs1.org/01/00614141123452",
+        ),
+        (
+            "https://example.com/gtin/614141123452",
+            "https://id.gs1.org/01/00614141123452",
+        ),
+        (
+            "https://example.com/gtin/614141123452/cpv/2A/lot/ABC123",
+            "https://id.gs1.org/01/00614141123452/22/2A/10/ABC123",
+        ),
+        (
+            "https://example.com/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123&foo=bar",
+            "https://id.gs1.org/00/106141412345678908?02=00614141123452&37=25&10=ABC123",
+        ),
+    ],
+)
+def test_as_canonical_uri(value: str, expected: str) -> None:
+    assert GS1WebURI.parse(value).as_canonical_uri() == expected
+
+
+@pytest.mark.parametrize(
     ("value", "ai", "expected"),
     [
         ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "01", ["00614141123452"]),

--- a/tests/test_gs1_web_uris.py
+++ b/tests/test_gs1_web_uris.py
@@ -323,6 +323,31 @@ def test_as_canonical_uri(value: str, expected: str) -> None:
 
 
 @pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (
+            "https://example.com/01/614141123452",
+            "(01)00614141123452",
+        ),
+        (
+            "https://example.com/gtin/614141123452",
+            "(01)00614141123452",
+        ),
+        (
+            "https://example.com/gtin/614141123452/cpv/2A/lot/ABC123",
+            "(01)00614141123452(22)2A(10)ABC123",
+        ),
+        (
+            "https://example.com/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123&foo=bar",
+            "(00)106141412345678908(02)00614141123452(37)25(10)ABC123",
+        ),
+    ],
+)
+def test_as_gs1_message(value: str, expected: str) -> None:
+    assert GS1WebURI.parse(value).as_gs1_message().as_hri() == expected
+
+
+@pytest.mark.parametrize(
     ("value", "ai", "expected"),
     [
         ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "01", ["00614141123452"]),

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -717,6 +717,81 @@ from biip.upc import Upc, UpcFormat
                 ),
             ),
         ),
+        (
+            # GS1 Web URI with GTIN-12, lot number, and expiration date with GS1
+            # QR Code symbology identifier
+            "]Q3https://example.com/gtin/614141123452/lot/ABC123?15=250330",
+            ParseResult(
+                value="]Q3https://example.com/gtin/614141123452/lot/ABC123?15=250330",
+                symbology_identifier=SymbologyIdentifier(
+                    value="]Q3",
+                    iso_symbology=ISOSymbology.QR_CODE,
+                    modifiers="3",
+                    gs1_symbology=GS1Symbology.GS1_QR_CODE,
+                ),
+                gtin=Gtin(
+                    value="00614141123452",
+                    format=GtinFormat.GTIN_12,
+                    prefix=GS1Prefix(value="061", usage="GS1 US"),
+                    company_prefix=GS1CompanyPrefix(value="0614141"),
+                    payload="61414112345",
+                    check_digit=2,
+                ),
+                upc=Upc(
+                    value="614141123452",
+                    format=UpcFormat.UPC_A,
+                    number_system_digit=6,
+                    payload="61414112345",
+                    check_digit=2,
+                ),
+                gs1_message_error=(
+                    "Failed to get GS1 Application Identifier from "
+                    "'https://example.com/gtin/614141123452/lot/ABC123?15=250330'."
+                ),
+                gs1_web_uri=GS1WebURI(
+                    value="https://example.com/gtin/614141123452/lot/ABC123?15=250330",
+                    element_strings=GS1ElementStrings(
+                        [
+                            GS1ElementString(
+                                ai=GS1ApplicationIdentifier.extract("01"),
+                                value="00614141123452",
+                                pattern_groups=["00614141123452"],
+                                gtin=Gtin(
+                                    value="00614141123452",
+                                    format=GtinFormat.GTIN_12,
+                                    prefix=GS1Prefix(value="061", usage="GS1 US"),
+                                    company_prefix=GS1CompanyPrefix(value="0614141"),
+                                    payload="61414112345",
+                                    check_digit=2,
+                                ),
+                            ),
+                            GS1ElementString(
+                                ai=GS1ApplicationIdentifier.extract("10"),
+                                value="ABC123",
+                                pattern_groups=["ABC123"],
+                            ),
+                            GS1ElementString(
+                                ai=GS1ApplicationIdentifier.extract("15"),
+                                value="250330",
+                                pattern_groups=[
+                                    "250330",
+                                ],
+                                gln=None,
+                                gln_error=None,
+                                gtin=None,
+                                gtin_error=None,
+                                sscc=None,
+                                sscc_error=None,
+                                date=dt.date(2025, 3, 30),
+                                datetime=None,
+                                decimal=None,
+                                money=None,
+                            ),
+                        ]
+                    ),
+                ),
+            ),
+        ),
     ],
 )
 def test_parse(value: str, expected: ParseResult) -> None:

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -13,6 +13,11 @@ def test_gs1_symbology_with_gs1_messages() -> None:
     assert GS1Symbology.GS1_128 in GS1Symbology.with_gs1_messages()
 
 
+def test_gs1_symbology_with_gs1_web_uri() -> None:
+    assert GS1Symbology.GS1_DATAMATRIX in GS1Symbology.with_gs1_web_uri()
+    assert GS1Symbology.GS1_QR_CODE in GS1Symbology.with_gs1_web_uri()
+
+
 def test_gs1_symbology_with_gtin() -> None:
     assert GS1Symbology.EAN_13 in GS1Symbology.with_gtin()
 


### PR DESCRIPTION
This PR adds support for parsing GS1 Web URIs. Web URIs can encode the same information as GS1 Messages, but in an http URL format, so that e.g. QR Codes with the URI can both work as a link to a website for a consumer and encode data needed in the supply chain.

Fixes #83

### TODO

- [x] Move `GS1ElementString` out of `biip.gs1_messages`
- [x] Rename `ParseConfig.gs1_message_verify_date` to `ParseConfig.gs1_element_string_verify_date`
- [x] Implement `GS1WebURI.parse()`
- [x] Implement `GS1WebURI.get()` and `GS1WebURI.filter()`
- [x] Add Web URI support to `biip.parse()`
- [x] Implement `GS1WebURI.as_canonical_uri()`
- [x] Implement `GS1WebURI.as_gs1_message()`
- [x] Implement `GS1Message.as_gs1_web_uri()`
- [x] Update features list
- [x] Add example to quickstart guide