### PR TITLE
Rename `config gs1_{message => element_string}_verify_date`

### DIFF
--- a/src/biip/_config.py
+++ b/src/biip/_config.py
@@ -17,8 +17,8 @@ class ParseConfig:
     some of its the behavior by setting these options.
     """
 
-    gs1_message_verify_date: bool = True
-    """Whether to verify that the date in a GS1 message is valid.
+    gs1_element_strings_verify_date: bool = True
+    """Whether to verify that the date in a GS1 element string is valid.
 
     According to the GS1 General Specification, dates are required to contain a
     valid year and month. Only the day of month can be left as zeros, which

--- a/src/biip/gs1_element_strings.py
+++ b/src/biip/gs1_element_strings.py
@@ -244,7 +244,7 @@ class GS1ElementString:
         try:
             self.date, self.datetime = _parse_date_and_datetime(self.value)
         except ValueError as exc:
-            if not config.gs1_message_verify_date:
+            if not config.gs1_element_strings_verify_date:
                 return
             msg = f"Failed to parse GS1 AI {self.ai} date/time from {self.value!r}."
             raise ParseError(msg) from exc

--- a/tests/test_gs1_messages.py
+++ b/tests/test_gs1_messages.py
@@ -124,7 +124,7 @@ def test_parse_with_separator_char(
         (
             # Invalid date "000000"
             "15000000",
-            ParseConfig(gs1_message_verify_date=False),
+            ParseConfig(gs1_element_strings_verify_date=False),
             GS1Message(
                 value="15000000",
                 element_strings=[


### PR DESCRIPTION
As this config applies to everything using GS1 element strings, like GS1 Web URIs, not just GS1 messages.

Not breaking, as this config was added after the last release.