### PR TITLE
Remove suffix from API docs headers

### DIFF
--- a/docs/api/checksums.md
+++ b/docs/api/checksums.md
@@ -1,3 +1,3 @@
-# `biip.checksums` - Checksums
+# `biip.checksums`
 
 ::: biip.checksums

--- a/docs/api/gln.md
+++ b/docs/api/gln.md
@@ -1,3 +1,3 @@
-# `biip.gln` - Global Location Number
+# `biip.gln`
 
 ::: biip.gln

--- a/docs/api/gs1_application_identifiers.md
+++ b/docs/api/gs1_application_identifiers.md
@@ -1,3 +1,3 @@
-# `biip.gs1_application_identifiers` - GS1 application identifiers
+# `biip.gs1_application_identifiers`
 
 ::: biip.gs1_application_identifiers

--- a/docs/api/gs1_element_strings.md
+++ b/docs/api/gs1_element_strings.md
@@ -1,3 +1,3 @@
-# `biip.gs1_element_strings` - GS1 element strings
+# `biip.gs1_element_strings`
 
 ::: biip.gs1_element_strings

--- a/docs/api/gs1_messages.md
+++ b/docs/api/gs1_messages.md
@@ -1,3 +1,3 @@
-# `biip.gs1_messages` - GS1 messages
+# `biip.gs1_messages`
 
 ::: biip.gs1_messages

--- a/docs/api/gs1_prefixes.md
+++ b/docs/api/gs1_prefixes.md
@@ -1,3 +1,3 @@
-# `biip.gs1_prefixes` - GS1 prefixes
+# `biip.gs1_prefixes`
 
 ::: biip.gs1_prefixes

--- a/docs/api/gtin.md
+++ b/docs/api/gtin.md
@@ -1,3 +1,3 @@
-# `biip.gtin` - Global Trade Item Number
+# `biip.gtin`
 
 ::: biip.gtin

--- a/docs/api/rcn.md
+++ b/docs/api/rcn.md
@@ -1,4 +1,4 @@
-# `biip.rcn` - Restricted Circulation Number
+# `biip.rcn`
 
 ::: biip.rcn
     options:

--- a/docs/api/sscc.md
+++ b/docs/api/sscc.md
@@ -1,3 +1,3 @@
-# `biip.sscc` - Serial Shipping Container Code
+# `biip.sscc`
 
 ::: biip.sscc

--- a/docs/api/symbology.md
+++ b/docs/api/symbology.md
@@ -1,3 +1,3 @@
-# `biip.symbology` - Symbology Identifiers
+# `biip.symbology`
 
 ::: biip.symbology

--- a/docs/api/upc.md
+++ b/docs/api/upc.md
@@ -1,3 +1,3 @@
-# `biip.upc` - Universal Product Code
+# `biip.upc`
 
 ::: biip.upc


### PR DESCRIPTION
This creates more noise than it is helpful. The introduction on each page spells out what the module name means.