### PR TITLE
GS1 Digital Link URI v1.6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ The library can interpret the following formats:
 - GS1 AI element strings,
   commonly found in GS1-128 barcodes.
 
+- GS1 Digital Link URIs,
+  commonly found in QR codes and Data Matrix barcodes.
+
 - UPC-A and UPC-E numbers, as found in UPC-A and UPC-E barcodes.
 
 For a quickstart guide and a complete API reference,

--- a/docs/api/gs1_digital_link_uris.md
+++ b/docs/api/gs1_digital_link_uris.md
@@ -1,0 +1,3 @@
+# `biip.gs1_digital_link_uris`
+
+::: biip.gs1_digital_link_uris

--- a/docs/api/gs1_web_uris.md
+++ b/docs/api/gs1_web_uris.md
@@ -1,3 +1,0 @@
-# `biip.gs1_web_uris`
-
-::: biip.gs1_web_uris

--- a/docs/index.md
+++ b/docs/index.md
@@ -143,6 +143,8 @@ Code](https://en.wikipedia.org/wiki/QR_code) barcode symbologies.
       domains, path prefixes, and with short names instead of AIs for the fields
       encoded in the path.
 - [x] Encode as GS1 messages.
+- [ ] Parse compressed GS1 Digital Link URIs is not supported.
+- [ ] Encode as compressed GS1 Dgitial Link URIs is not supported.
 
 ### GLN (Global Location Number)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -124,22 +124,24 @@ including
 - [x] Parse Human Readable Interpretation (HRI) strings.
 - [x] Easy lookup of parsed Element Strings by Application Identifier (AI)
       prefix and part of AI's data title.
-- [x] Encode as GS1 Web URIs.
+- [x] Encode as GS1 Digital Link URIs.
 
-### GS1 Web URIs
+### GS1 Digital Link URIs
 
-GS1 Web URIs are used to encode the same information as GS1 messages, but as the
-path and query parameters of an URL. The URL can point to any domain. This means
-that barcodes containing GS1 Web URIs can be used both in the supply chain and
-for consumers to look up product information. GS1 Web URIs are used in the
-[GS1 DataMatrix](https://en.wikipedia.org/wiki/Data_Matrix) and
-[GS1 QR Code](https://en.wikipedia.org/wiki/QR_code)
-barcode symbologies.
+GS1 Digital Link URIs are used to encode the same information as GS1 messages,
+but as the path and query parameters of an URL. The URL can point to any domain.
+This means that barcodes containing GS1 Digital Link URIs can be used both in
+the supply chain and for consumers to look up product information. GS1 Digital
+Link URIs are used in the [GS1
+DataMatrix](https://en.wikipedia.org/wiki/Data_Matrix) and [GS1 QR
+Code](https://en.wikipedia.org/wiki/QR_code) barcode symbologies.
 
-- [x] Everything supported for GS1 messages are also supported for GS1 Web URIs.
-- [x] Parse GS1 Web URIs, both canonical and non-canonical URIs.
-- [x] Encode GS1 Web URIs, both canonical and with custom domains, path
-      prefixes, and with short names instead of AIs for the fields encoded in the path.
+- [x] Everything supported for GS1 messages are also supported for GS1 Digital
+      Link URIs.
+- [x] Parse GS1 Digital Link URIs, both canonical and non-canonical URIs.
+- [x] Encode GS1 Digital Link URIs, both canonical and with custom
+      domains, path prefixes, and with short names instead of AIs for the fields
+      encoded in the path.
 - [x] Encode as GS1 messages.
 
 ### GLN (Global Location Number)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -570,7 +570,7 @@ supply chain. Using the GS1 Digital Link URI specification, they create the
 following URI:
 
 ```
-https://www.example.com/products/gtin/07032069804988?10=0329&15=210526
+https://www.example.com/products/01/07032069804988?10=0329&15=210526
 ```
 
 They put this in a GS1 QR code or a GS1 DataMatrix barcode, and print it on the
@@ -579,10 +579,10 @@ product.
 When a consumer scans the barcode, they are taken to the product page. When the supply chain scans this barcode and use Biip to parse it, they get the following result:
 
 ```python
->>> result = biip.parse("https://www.example.com/products/gtin/07032069804988?10=0329&15=210526")
+>>> result = biip.parse("https://www.example.com/products/01/07032069804988?10=0329&15=210526")
 >>> print(result)
 ParseResult(
-    value='https://www.example.com/products/gtin/07032069804988?10=0329&15=210526',
+    value='https://www.example.com/products/01/07032069804988?10=0329&15=210526',
     gtin=Gtin(
         value='07032069804988',
         format=GtinFormat.GTIN_13,
@@ -592,7 +592,7 @@ ParseResult(
         check_digit=8
     ),
     gs1_digital_link_uri=GS1DigitalLinkURI(
-        value='https://www.example.com/products/gtin/07032069804988?10=0329&15=210526',
+        value='https://www.example.com/products/01/07032069804988?10=0329&15=210526',
         element_strings=[
             GS1ElementString(
                 ai=GS1ApplicationIdentifier(
@@ -669,12 +669,6 @@ Digital Link URI, Biip can also be helpful:
 ...    prefix="database",
 ... )
 'https://another.example.net/database/01/07032069804988/10/0329?15=210526'
->>> dl_uri.as_uri(
-...    domain="another.example.net",
-...    prefix="database",
-...    short_names=True,
-... )
-'https://another.example.net/database/gtin/07032069804988/lot/0329?15=210526'
 ```
 
 ## Deep dive

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -552,21 +552,22 @@ we also need to tell Biip what character to expect by creating a
 
 Once again, all three element strings was successfully extracted.
 
-## GS1 Web URIs
+## GS1 Digital Link URIs
 
 In an effort to make a single barcode that is useful both in the supply chain
 and for consumers wanting to learn more about the product they've purchased, GS1
-has developed the GS1 Web URI standard.
+has developed the GS1 Digital Link URI standard.
 
-GS1 Web URIs are HTTP URIs that can contain any domain name and any path prefix,
-and then encodes the element strings as path segments and query parameters in a
-standardized way.
+GS1 Digital Link URIs are HTTP URIs that can contain any domain name and any
+path prefix, and then encodes the element strings as path segments and query
+parameters in a standardized way.
 
 Let's assume that an imaginary manufacturer named Example Inc. wants to create a
 barcode for a product with GTIN `07032069804988`. The URI should link to their
 product information page. The barcode should also encode the batch number `0329`
 and the expiration date `2021-05-26` for easy tracking of the items through the
-supply chain. Using the GS1 Web URI specification, they create the following URI:
+supply chain. Using the GS1 Digital Link URI specification, they create the
+following URI:
 
 ```
 https://www.example.com/products/gtin/07032069804988?10=0329&15=210526
@@ -590,7 +591,7 @@ ParseResult(
         payload='703206980498',
         check_digit=8
     ),
-    gs1_web_uri=GS1WebURI(
+    gs1_digital_link_uri=GS1DigitalLinkURI(
         value='https://www.example.com/products/gtin/07032069804988?10=0329&15=210526',
         element_strings=[
             GS1ElementString(
@@ -643,32 +644,32 @@ ParseResult(
 As you can see, Biip has extracted the GTIN, batch number and expiration date,
 just like we're used to with traditional GS1 message barcodes.
 
-You can also use Biip to convert the result to a canonical GS1 Web URI:
+You can also use Biip to convert the result to a canonical GS1 Digital Link URI:
 
 ```python
->>> result.gs1_web_uri.as_canonical_uri()
+>>> result.gs1_digital_link_uri.as_canonical_uri()
 'https://id.gs1.org/01/07032069804988/10/0329?15=210526'
 ```
 
 Or to convert it to a GS1 message and print the equivalent HRI representation:
 
 ```python
->>> message = result.gs1_web_uri.as_gs1_message()
+>>> message = result.gs1_digital_link_uri.as_gs1_message()
 >>> message.as_hri()
 '(01)07032069804988(10)0329(15)210526'
 ```
 
-If you have an existing GS1 message barcode and want to convert it to a GS1 Web
-URI, Biip can also be helpful:
+If you have an existing GS1 message barcode and want to convert it to a GS1
+Digital Link URI, Biip can also be helpful:
 
 ```python
->>> web_uri = message.as_gs1_web_uri()
->>> web_uri.as_uri(
+>>> dl_uri = message.as_gs1_digital_link_uri()
+>>> dl_uri.as_uri(
 ...    domain="another.example.net",
 ...    prefix="database",
 ... )
 'https://another.example.net/database/01/07032069804988/10/0329?15=210526'
->>> web_uri.as_uri(
+>>> dl_uri.as_uri(
 ...    domain="another.example.net",
 ...    prefix="database",
 ...    short_names=True,

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -4,6 +4,53 @@ When major versions of Biip are released, we try to keep the upgrade path as
 smooth as possible. However, there are some breaking changes that you need to
 consider when upgrading from one major version to another.
 
+## Upgrading from 4.x to 5.x
+
+### GS1 Web URIs are now GS1 Digital Link URIs
+
+GS1 Digital Link standard v1.1 renamed the concept from "Web URI" to "Digital
+Link URI". The corresponding APIs in Biip have been renamed.
+
+- `biip.ParseResult.gs1_web_uri` field has moved to
+  [`biip.ParseResult.gs1_digital_link_uri`][biip.ParseResult.gs1_digital_link_uri]
+  (PR #396)
+
+- `biip.ParseResult.gs1_web_uri_error` field has moved to
+  [`biip.ParseResult.gs1_digital_link_uri_error`][biip.ParseResult.gs1_digital_link_uri_error]
+  (PR #396)
+
+- `biip.gs1_messages.GS1Message.as_gs1_web_uri()` has moved to
+  [`biip.gs1_messages.GS1Message.as_gs1_digital_link_uri()`][biip.gs1_messages.GS1Message.as_gs1_digital_link_uri]
+  (PR #396)
+
+- `biip.gs1_web_uris.GS1WebURI` has moved to
+  [`biip.gs1_digital_link_uris.GS1DigitalLinkURI`][biip.gs1_digital_link_uris.GS1DigitalLinkURI]
+  (PR #396)
+
+- `biip.symbology.GS1Symbology.with_gs1_web_uri()` has moved to
+  [`biip.symbology.GS1Symbology.with_gs1_digital_link_uri()`][biip.symbology.GS1Symbology.with_gs1_digital_link_uri]
+  (PR #396)
+
+### GS1 Application Identifier aliases in URIs are not supported
+
+GS1 Digital Link standard v1.2 deprecated and v1.3 removed the concept of
+aliases. Biip no longer supports aliases in URIs, as this is recommended to not
+support in newer implementations to reduce complexity.
+
+That is, the following is not supported:
+
+```
+https://id.gs1.org/gtin/07032069804988100329/lot/ABC
+```
+
+But this is supported:
+
+```
+https://id.gs1.org/01/07032069804988100329/10/ABC
+```
+
+(Fixes: #394, PR: #396)
+
 ## Upgrading from 3.x to 4.x
 
 ### Result objects are immutable

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -15,10 +15,10 @@ nav:
       - api/checksums.md
       - api/gln.md
       - api/gs1_application_identifiers.md
+      - api/gs1_digital_link_uris.md
       - api/gs1_element_strings.md
       - api/gs1_messages.md
       - api/gs1_prefixes.md
-      - api/gs1_web_uris.md
       - api/gtin.md
       - api/rcn.md
       - api/sscc.md

--- a/src/biip/gs1_digital_link_uris.py
+++ b/src/biip/gs1_digital_link_uris.py
@@ -407,51 +407,72 @@ class _Component:
 
 _PRIMARY_IDENTIFIERS = [
     _Component(
-        ai=GS1ApplicationIdentifier.extract("01"),
+        ai=GS1ApplicationIdentifier.extract("01"),  # gtin
         zfill_to_width=14,
         qualifiers=(
-            _Component(ai=GS1ApplicationIdentifier.extract("22")),
-            _Component(ai=GS1ApplicationIdentifier.extract("10")),
-            _Component(ai=GS1ApplicationIdentifier.extract("21")),
+            _Component(ai=GS1ApplicationIdentifier.extract("22")),  # cpv
+            _Component(ai=GS1ApplicationIdentifier.extract("10")),  # lot
+            _Component(ai=GS1ApplicationIdentifier.extract("21")),  # ser
+            _Component(ai=GS1ApplicationIdentifier.extract("235")),  # tpx
         ),
     ),
     _Component(
-        ai=GS1ApplicationIdentifier.extract("8006"),
+        ai=GS1ApplicationIdentifier.extract("8006"),  # itip
         qualifiers=(
-            _Component(ai=GS1ApplicationIdentifier.extract("22")),
-            _Component(ai=GS1ApplicationIdentifier.extract("10")),
-            _Component(ai=GS1ApplicationIdentifier.extract("21")),
+            _Component(ai=GS1ApplicationIdentifier.extract("22")),  # cpv
+            _Component(ai=GS1ApplicationIdentifier.extract("10")),  # lot
+            _Component(ai=GS1ApplicationIdentifier.extract("21")),  # ser
         ),
     ),
-    _Component(ai=GS1ApplicationIdentifier.extract("8013")),
+    _Component(ai=GS1ApplicationIdentifier.extract("8013")),  # gmn
     _Component(
-        ai=GS1ApplicationIdentifier.extract("8010"),
-        qualifiers=(_Component(ai=GS1ApplicationIdentifier.extract("8011")),),
-    ),
-    _Component(ai=GS1ApplicationIdentifier.extract("410")),
-    _Component(ai=GS1ApplicationIdentifier.extract("411")),
-    _Component(ai=GS1ApplicationIdentifier.extract("412")),
-    _Component(ai=GS1ApplicationIdentifier.extract("413")),
-    _Component(
-        ai=GS1ApplicationIdentifier.extract("414"),
-        qualifiers=(_Component(ai=GS1ApplicationIdentifier.extract("254")),),
-    ),
-    _Component(ai=GS1ApplicationIdentifier.extract("415")),
-    _Component(ai=GS1ApplicationIdentifier.extract("416")),
-    _Component(
-        ai=GS1ApplicationIdentifier.extract("8017"),
-        qualifiers=(_Component(ai=GS1ApplicationIdentifier.extract("8019")),),
+        ai=GS1ApplicationIdentifier.extract("8010"),  # cpid
+        qualifiers=(
+            _Component(ai=GS1ApplicationIdentifier.extract("8011")),  # cpsn
+        ),
     ),
     _Component(
-        ai=GS1ApplicationIdentifier.extract("8018"),
-        qualifiers=(_Component(ai=GS1ApplicationIdentifier.extract("8019")),),
+        ai=GS1ApplicationIdentifier.extract("414"),  # gln
+        qualifiers=(
+            _Component(ai=GS1ApplicationIdentifier.extract("254")),  # glnx
+            _Component(ai=GS1ApplicationIdentifier.extract("7040")),  # uic-ext
+        ),
     ),
-    _Component(ai=GS1ApplicationIdentifier.extract("255")),
-    _Component(ai=GS1ApplicationIdentifier.extract("00")),
-    _Component(ai=GS1ApplicationIdentifier.extract("253")),
-    _Component(ai=GS1ApplicationIdentifier.extract("401")),
-    _Component(ai=GS1ApplicationIdentifier.extract("402")),
-    _Component(ai=GS1ApplicationIdentifier.extract("8003")),
-    _Component(ai=GS1ApplicationIdentifier.extract("8004")),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("415"),  # payTo
+        qualifiers=(
+            _Component(ai=GS1ApplicationIdentifier.extract("8020")),  # refNo
+        ),
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("417"),  # partyGln
+        qualifiers=(
+            _Component(ai=GS1ApplicationIdentifier.extract("7040")),  # uic-ext
+        ),
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("8017"),  # gsrnp
+        qualifiers=(
+            _Component(ai=GS1ApplicationIdentifier.extract("8019")),  # srin
+        ),
+    ),
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("8018"),  # gsrn
+        qualifiers=(
+            _Component(ai=GS1ApplicationIdentifier.extract("8019")),  # srin
+        ),
+    ),
+    _Component(ai=GS1ApplicationIdentifier.extract("255")),  # gcn
+    _Component(ai=GS1ApplicationIdentifier.extract("00")),  # sscc
+    _Component(ai=GS1ApplicationIdentifier.extract("253")),  # gdti
+    _Component(ai=GS1ApplicationIdentifier.extract("401")),  # ginc
+    _Component(ai=GS1ApplicationIdentifier.extract("402")),  # gsin
+    _Component(ai=GS1ApplicationIdentifier.extract("8003")),  # grai
+    _Component(
+        ai=GS1ApplicationIdentifier.extract("8004"),  # giai
+        qualifiers=(
+            _Component(ai=GS1ApplicationIdentifier.extract("7040")),  # uic-ext
+        ),
+    ),
 ]
 _PRIMARY_IDENTIFIER_MAP = {pi.ai.ai: pi for pi in _PRIMARY_IDENTIFIERS}

--- a/src/biip/gs1_digital_link_uris.py
+++ b/src/biip/gs1_digital_link_uris.py
@@ -1,37 +1,39 @@
-"""Support for GS1 Web URIs.
+"""Support for GS1 Digital Link URIs.
 
-GS1 Web URIs are HTTP(S) URIs pointing to any hostname, optionally with a path
-prefix, where GS1 element strings are encoded in the path and query parameters.
+GS1 Digital Link URIs are HTTPS URIs pointing to any hostname, optionally with a
+path prefix, where GS1 element strings are encoded in the path and query
+parameters.
 
-Examples of GS1 Web URIs:
+Examples of GS1 Digital Link URIs:
 
 - `https://id.gs1.org/gtin/614141123452/lot/ABC1/ser/12345?exp=180426`
 - `https://id.gs1.org/gtin/614141123452?3103=000195`
 - `https://id.gs1.org/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123`
 
-This makes it possible to use GS1 Web URIs encoded in 2D barcodes both in
-supply chain and logistics applications, as well as for consumers to look up
+This makes it possible to use GS1 Digital Link URIs encoded in 2D barcodes both
+in supply chain and logistics applications, as well as for consumers to look up
 product information.
 
 References:
-    https://www.gs1.org/standards/Digital-Link/1-0
+    https://www.gs1.org/standards/gs1-digital-link
 
 ## Example
 
-If you only want to parse GS1 Web URIs, you can import the GS1 Web URI parser
-directly instead of using [`biip.parse()`][biip.parse].
+If you only want to parse GS1 Digital Link URIs, you can import the GS1 Digital
+Link URI parser directly instead of using [`biip.parse()`][biip.parse].
 
-    >>> from biip.gs1_web_uris import GS1WebURI
+    >>> from biip.gs1_digital_link_uris import GS1DigitalLinkURI
 
-If the parsing succeeds, it returns a [`GS1WebURI`][biip.gs1_web_uris.GS1WebURI] object.
+If the parsing succeeds, it returns a
+[`GS1DigitalLinkURI`][biip.gs1_digital_link_uris.GS1DigitalLinkURI] object.
 
-    >>> web_uri = GS1WebURI.parse("https://id.gs1.org/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123")
+    >>> dl_uri = GS1DigitalLinkURI.parse("https://id.gs1.org/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123")
 
 In this case, the URI is parsed into the SSCC of a shipping container, the GTIN
 of the product within the shipping container, the number of item within, and the
 batch number.
 
-    >>> pprint(web_uri.element_strings)
+    >>> pprint(dl_uri.element_strings)
     [
         GS1ElementString(
             ai=GS1ApplicationIdentifier(
@@ -135,8 +137,8 @@ if TYPE_CHECKING:
 
 
 @dataclass(frozen=True)
-class GS1WebURI:
-    """A GS1 Web URI is a URI that contains GS1 element strings."""
+class GS1DigitalLinkURI:
+    """A GS1 Digital Link URI is a URI that contains GS1 element strings."""
 
     value: str
     """Raw unprocessed value."""
@@ -154,15 +156,15 @@ class GS1WebURI:
         value: str,
         *,
         config: ParseConfig | None = None,
-    ) -> GS1WebURI:
-        """Parse a string as a GS1 Web URI.
+    ) -> GS1DigitalLinkURI:
+        """Parse a string as a GS1 Digital Link URI.
 
         Args:
             value: The string to parse.
             config: The parse configuration.
 
         Returns:
-            The parsed GS1 Web URI.
+            The parsed GS1 Digital Link URI.
 
         Raises:
             ParseError: If the parsing fails.
@@ -244,16 +246,18 @@ class GS1WebURI:
         return cls(value=value, element_strings=element_strings)
 
     @classmethod
-    def from_element_strings(cls, element_strings: GS1ElementStrings) -> GS1WebURI:
-        """Create a GS1 Web URI from a list of GS1 element strings.
+    def from_element_strings(
+        cls, element_strings: GS1ElementStrings
+    ) -> GS1DigitalLinkURI:
+        """Create a GS1 Digital Link URI from a list of GS1 element strings.
 
         Args:
             element_strings: A list of GS1 element strings.
 
         Returns:
-            GS1WebURI: The created GS1 Web URI.
+            GS1DigitalLinkURI: The created GS1 Digital Link URI.
         """
-        return GS1WebURI(
+        return GS1DigitalLinkURI(
             value=_build_url(element_strings),
             element_strings=element_strings,
         )
@@ -265,7 +269,7 @@ class GS1WebURI:
         prefix: str | None = None,
         short_names: bool = False,
     ) -> str:
-        """Render as a GS1 Web URI.
+        """Render as a GS1 Digital Link URI.
 
         Args:
             domain: The domain name to use in the URI. Defaults to `id.gs1.org`.
@@ -274,7 +278,7 @@ class GS1WebURI:
                 path. Defaults to False.
 
         Returns:
-            str: The GS1 Web URI.
+            str: The GS1 Digital Link URI.
         """
         return _build_url(
             self.element_strings,
@@ -284,7 +288,7 @@ class GS1WebURI:
         )
 
     def as_canonical_uri(self) -> str:
-        """Render as a canonical GS1 Web URI.
+        """Render as a canonical GS1 Digital Link URI.
 
         Canonical URIs:
 
@@ -293,15 +297,15 @@ class GS1WebURI:
         - Excludes all query parameters that are not valid application identifiers.
 
         Returns:
-            str: The canonical GS1 Web URI.
+            str: The canonical GS1 Digital Link URI.
 
         References:
-            GS1 Web URI Structure Standard, section 5.2
+            GS1 Digital Link Standard: URI Syntax, section 4.12
         """
         return _build_url(self.element_strings)
 
     def as_gs1_message(self) -> GS1Message:
-        """Converts the GS1 Web URI to a GS1 Message."""
+        """Converts the GS1 Digital Link URI to a GS1 Message."""
         from biip.gs1_messages import GS1Message
 
         return GS1Message.from_element_strings(self.element_strings)

--- a/src/biip/gs1_digital_link_uris.py
+++ b/src/biip/gs1_digital_link_uris.py
@@ -258,7 +258,7 @@ class GS1DigitalLinkURI:
             GS1DigitalLinkURI: The created GS1 Digital Link URI.
         """
         return GS1DigitalLinkURI(
-            value=_build_url(element_strings),
+            value=_build_uri(element_strings),
             element_strings=element_strings,
         )
 
@@ -280,7 +280,7 @@ class GS1DigitalLinkURI:
         Returns:
             str: The GS1 Digital Link URI.
         """
-        return _build_url(
+        return _build_uri(
             self.element_strings,
             domain=domain or "id.gs1.org",
             prefix=prefix,
@@ -302,7 +302,7 @@ class GS1DigitalLinkURI:
         References:
             GS1 Digital Link Standard: URI Syntax, section 4.12
         """
-        return _build_url(self.element_strings)
+        return _build_uri(self.element_strings)
 
     def as_gs1_message(self) -> GS1Message:
         """Converts the GS1 Digital Link URI to a GS1 Message."""
@@ -344,7 +344,7 @@ def _get_qualifier(
     raise ParseError(msg)
 
 
-def _build_url(
+def _build_uri(
     element_strings: GS1ElementStrings,
     *,
     domain: str = "id.gs1.org",

--- a/src/biip/gs1_digital_link_uris.py
+++ b/src/biip/gs1_digital_link_uris.py
@@ -365,10 +365,6 @@ def _build_uri(
         if (es := element_strings.get(ai=q.ai))
     ]
 
-    other_element_strings = [
-        es for es in element_strings if es not in (pi_element_string, *qualifiers)
-    ]
-
     if prefix is not None:
         if prefix.startswith("/"):
             msg = "Prefix must not start with '/'"
@@ -385,7 +381,12 @@ def _build_uri(
     for element_string in qualifiers:
         path += f"/{element_string.ai.ai}/{element_string.value}"
 
-    params: dict[str, str] = {es.ai.ai: es.value for es in other_element_strings}
+    other_element_strings = [
+        es for es in element_strings if es not in (pi_element_string, *qualifiers)
+    ]
+    # Sort params by AI in lexicographical order
+    sorted_element_strings = sorted(other_element_strings, key=lambda es: es.ai.ai)
+    params: dict[str, str] = {es.ai.ai: es.value for es in sorted_element_strings}
 
     return urlunsplit(
         [

--- a/src/biip/gs1_element_strings.py
+++ b/src/biip/gs1_element_strings.py
@@ -2,8 +2,8 @@
 
 An element string consists of a GS1 Application Identifier (AI) and its data field.
 
-Element strings are usually found in a GS1 message or a GS1 Web URI. A single
-barcode can contain multiple element strings.
+Element strings are usually found in a GS1 message or a GS1 Digital Link URI. A
+single barcode can contain multiple element strings.
 
 Examples:
     >>> from biip.gs1_element_strings import GS1ElementString

--- a/src/biip/gs1_messages.py
+++ b/src/biip/gs1_messages.py
@@ -123,7 +123,7 @@ from biip.gs1_application_identifiers import _GS1_APPLICATION_IDENTIFIERS
 from biip.gs1_element_strings import GS1ElementString, GS1ElementStrings
 
 if TYPE_CHECKING:
-    from biip.gs1_web_uris import GS1WebURI
+    from biip.gs1_digital_link_uris import GS1DigitalLinkURI
 
 
 @dataclass(frozen=True)
@@ -267,8 +267,8 @@ class GS1Message:
         """
         return "".join(es.as_hri() for es in self.element_strings)
 
-    def as_gs1_web_uri(self) -> GS1WebURI:
-        """Convert to a GS1 Web URI."""
-        from biip.gs1_web_uris import GS1WebURI
+    def as_gs1_digital_link_uri(self) -> GS1DigitalLinkURI:
+        """Convert to a GS1 Digital Link URI."""
+        from biip.gs1_digital_link_uris import GS1DigitalLinkURI
 
-        return GS1WebURI.from_element_strings(self.element_strings)
+        return GS1DigitalLinkURI.from_element_strings(self.element_strings)

--- a/src/biip/symbology.py
+++ b/src/biip/symbology.py
@@ -207,8 +207,8 @@ class GS1Symbology(Enum):
         }
 
     @classmethod
-    def with_gs1_web_uri(cls) -> set[GS1Symbology]:
-        """Symbologies that may contain GS1 Web URIs."""
+    def with_gs1_digital_link_uri(cls) -> set[GS1Symbology]:
+        """Symbologies that may contain GS1 Digital Link URIs."""
         return {cls.GS1_DATAMATRIX, cls.GS1_QR_CODE}
 
     @classmethod

--- a/tests/test_gs1_digital_link_uris.py
+++ b/tests/test_gs1_digital_link_uris.py
@@ -15,10 +15,10 @@ from biip.sscc import Sscc
     ("value", "expected"),
     [
         (
-            # GTIN-12 by AI number
-            "https://id.gs1.org/01/614141123452",
+            # Canonical URI
+            "https://id.gs1.org/01/00614141123452",
             GS1DigitalLinkURI(
-                value="https://id.gs1.org/01/614141123452",
+                value="https://id.gs1.org/01/00614141123452",
                 element_strings=GS1ElementStrings(
                     [
                         GS1ElementString(
@@ -39,10 +39,10 @@ from biip.sscc import Sscc
             ),
         ),
         (
-            # GTIN-12 with custom domain, path prefix, and AI alias
-            "https://example.com/foo/gtin/614141123452",
+            # Custom domain and path prefix, with unpadded GTIN-12
+            "https://example.com/foo/01/614141123452",
             GS1DigitalLinkURI(
-                value="https://example.com/foo/gtin/614141123452",
+                value="https://example.com/foo/01/614141123452",
                 element_strings=GS1ElementStrings(
                     [
                         GS1ElementString(
@@ -63,10 +63,10 @@ from biip.sscc import Sscc
             ),
         ),
         (
-            # GTIN-12 and batch/lot number by AI number
-            "https://id.gs1.org/01/614141123452/10/ABC123",
+            # Canonical URI with lot number
+            "https://id.gs1.org/01/00614141123452/10/ABC123",
             GS1DigitalLinkURI(
-                value="https://id.gs1.org/01/614141123452/10/ABC123",
+                value="https://id.gs1.org/01/00614141123452/10/ABC123",
                 element_strings=GS1ElementStrings(
                     [
                         GS1ElementString(
@@ -92,44 +92,10 @@ from biip.sscc import Sscc
             ),
         ),
         (
-            # GTIN-12, CPV, and batch/lot number by AI alias
-            "https://id.gs1.org/gtin/614141123452/cpv/2A/lot/ABC123",
+            # GTIN-14 with extra query parameter that is ignored
+            "https://id.gs1.org/01/00614141123452?foo=bar",
             GS1DigitalLinkURI(
-                value="https://id.gs1.org/gtin/614141123452/cpv/2A/lot/ABC123",
-                element_strings=GS1ElementStrings(
-                    [
-                        GS1ElementString(
-                            ai=GS1ApplicationIdentifier.extract("01"),
-                            value="00614141123452",
-                            pattern_groups=["00614141123452"],
-                            gtin=Gtin(
-                                value="00614141123452",
-                                format=GtinFormat.GTIN_12,
-                                prefix=GS1Prefix(value="061", usage="GS1 US"),
-                                company_prefix=GS1CompanyPrefix(value="0614141"),
-                                payload="61414112345",
-                                check_digit=2,
-                            ),
-                        ),
-                        GS1ElementString(
-                            ai=GS1ApplicationIdentifier.extract("22"),
-                            value="2A",
-                            pattern_groups=["2A"],
-                        ),
-                        GS1ElementString(
-                            ai=GS1ApplicationIdentifier.extract("10"),
-                            value="ABC123",
-                            pattern_groups=["ABC123"],
-                        ),
-                    ]
-                ),
-            ),
-        ),
-        (
-            # GTIN-12 with extra query parameter that is ignored
-            "https://id.gs1.org/01/614141123452?foo=bar",
-            GS1DigitalLinkURI(
-                value="https://id.gs1.org/01/614141123452?foo=bar",
+                value="https://id.gs1.org/01/00614141123452?foo=bar",
                 element_strings=GS1ElementStrings(
                     [
                         GS1ElementString(
@@ -151,9 +117,9 @@ from biip.sscc import Sscc
         ),
         (
             # SSCC with content, count, and batch/lot number
-            "https://id.gs1.org/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123",
+            "https://id.gs1.org/00/106141412345678908?02=00614141123452&37=25&10=ABC123",
             GS1DigitalLinkURI(
-                value="https://id.gs1.org/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123",
+                value="https://id.gs1.org/00/106141412345678908?02=00614141123452&37=25&10=ABC123",
                 element_strings=GS1ElementStrings(
                     [
                         GS1ElementString(
@@ -210,10 +176,10 @@ def test_parse(value: str, expected: GS1DigitalLinkURI) -> None:
     [
         (
             # Invalid date "000000"
-            "https://id.gs1.org/gtin/614141123452?15=000000",
+            "https://id.gs1.org/01/614141123452?15=000000",
             ParseConfig(gs1_element_strings_verify_date=False),
             GS1DigitalLinkURI(
-                value="https://id.gs1.org/gtin/614141123452?15=000000",
+                value="https://id.gs1.org/01/614141123452?15=000000",
                 element_strings=GS1ElementStrings(
                     [
                         GS1ElementString(
@@ -269,28 +235,28 @@ def test_parse_with_invalid_element_values(
         ),
         (
             # The path must contain an even number of segments
-            "https://example.com/foo/gtin/614141123452/123",
-            r"^Expected even number of path segments, got '/gtin/614141123452/123'.$",
+            "https://example.com/foo/01/614141123452/123",
+            r"^Expected even number of path segments, got '/01/614141123452/123'.$",
         ),
         (
-            # "exp" is not a valid qualifier for GTIN
-            "https://id.gs1.org/gtin/614141123452/exp/20250324",
-            r"^Expected one of 22/cpv/10/lot/21/ser as qualifier, got 'exp'.$",
+            # "15" is not a valid qualifier for GTIN
+            "https://id.gs1.org/01/614141123452/15/20250324",
+            r"^Expected one of \(22, 10, 21\) as qualifier, got '15'.$",
         ),
         (
-            # "cpv" is a valid qualifier, but not after "lot"
-            "https://id.gs1.org/gtin/614141123452/lot/ABC123/cpv/123456789",
-            r"^Expected one of 21/ser as qualifier, got 'cpv'.$",
+            # "22" is a valid qualifier, but not after "10"
+            "https://id.gs1.org/01/614141123452/10/ABC123/22/123456789",
+            r"^Expected one of \(21\) as qualifier, got '22'.$",
         ),
         (
-            # "lot" is a valid qualifier, but not after "ser"
-            "https://id.gs1.org/gtin/01234567890128/ser/12345XYZ/lot/ABC123",
-            r"^Did not expect a qualifier, got 'lot'.$",
+            # "10" is a valid qualifier, but not after "21"
+            "https://id.gs1.org/01/01234567890128/21/12345XYZ/10/ABC123",
+            r"^Did not expect a qualifier, got '10'.$",
         ),
         (
-            # "lot" is not a valid qualifier for SSCC
-            "https://id.gs1.org/sscc/106141412345678908/lot/ABC123",
-            r"^Did not expect a qualifier, got 'lot'.$",
+            # "10" is not a valid qualifier for SSCC
+            "https://id.gs1.org/00/106141412345678908/10/ABC123",
+            r"^Did not expect a qualifier, got '10'.$",
         ),
     ],
 )
@@ -372,47 +338,29 @@ def test_from_element_strings(
 
 
 @pytest.mark.parametrize(
-    ("value", "domain", "prefix", "short_names", "expected"),
+    ("value", "domain", "prefix", "expected"),
     [
         (
-            # Defaults creates a canonical URI
+            # Defaults creates a canonical URI, using the canonical hostname,
+            # numerical AIs, 14-digit GTINs.
             "https://example.com/01/614141123452",
             None,
             None,
-            False,
             "https://id.gs1.org/01/00614141123452",
         ),
         (
             # Custom domain
-            "https://example.com/01/614141123452",
+            "https://id.gs1.org/01/00614141123452",
             "brand.example.net",
             None,
-            False,
             "https://brand.example.net/01/00614141123452",
         ),
         (
             # Custom domain with prefix
-            "https://example.com/gtin/614141123452",
+            "https://id.gs1.org/01/00614141123452",
             "brand.example.net",
             "prefix",
-            False,
             "https://brand.example.net/prefix/01/00614141123452",
-        ),
-        (
-            # Short names instead of AIs in path
-            "https://id.gs1.org/01/614141123452/22/2A/10/ABC123",
-            "example.com",
-            "products",
-            True,
-            "https://example.com/products/gtin/00614141123452/cpv/2A/lot/ABC123",
-        ),
-        (
-            # Values in params always use AI, not short names
-            "https://example.com/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123&foo=bar",
-            "brand.example.net",
-            None,
-            True,
-            "https://brand.example.net/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123",
         ),
     ],
 )
@@ -421,14 +369,12 @@ def test_as_uri(
     value: str,
     domain: str | None,
     prefix: str | None,
-    short_names: bool,
     expected: str,
 ) -> None:
     assert (
         GS1DigitalLinkURI.parse(value).as_uri(
             domain=domain,
             prefix=prefix,
-            short_names=short_names,
         )
         == expected
     )
@@ -436,11 +382,11 @@ def test_as_uri(
 
 def test_as_uri_errors() -> None:
     with pytest.raises(ValueError, match="Prefix must not start with '/'"):
-        GS1DigitalLinkURI.parse("https://example.com/gtin/614141123452").as_uri(
+        GS1DigitalLinkURI.parse("https://example.com/01/614141123452").as_uri(
             prefix="/prefix"
         )
     with pytest.raises(ValueError, match="Prefix must not end with '/'"):
-        GS1DigitalLinkURI.parse("https://example.com/gtin/614141123452").as_uri(
+        GS1DigitalLinkURI.parse("https://example.com/01/614141123452").as_uri(
             prefix="prefix/"
         )
 
@@ -449,19 +395,22 @@ def test_as_uri_errors() -> None:
     ("value", "expected"),
     [
         (
+            "https://example.com/01/00614141123452",
+            "https://id.gs1.org/01/00614141123452",
+        ),
+        (
+            # With deprecated GTIN length
             "https://example.com/01/614141123452",
             "https://id.gs1.org/01/00614141123452",
         ),
         (
-            "https://example.com/gtin/614141123452",
-            "https://id.gs1.org/01/00614141123452",
-        ),
-        (
-            "https://example.com/gtin/614141123452/cpv/2A/lot/ABC123",
+            # With deprecated GTIN length and qualifiers
+            "https://example.com/01/614141123452/22/2A/10/ABC123",
             "https://id.gs1.org/01/00614141123452/22/2A/10/ABC123",
         ),
         (
-            "https://example.com/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123&foo=bar",
+            # Extra query parameters are ignored
+            "https://example.com/00/106141412345678908?02=00614141123452&37=25&10=ABC123&foo=bar",
             "https://id.gs1.org/00/106141412345678908?02=00614141123452&37=25&10=ABC123",
         ),
     ],
@@ -474,19 +423,22 @@ def test_as_canonical_uri(value: str, expected: str) -> None:
     ("value", "expected"),
     [
         (
+            "https://example.com/01/00614141123452",
+            "(01)00614141123452",
+        ),
+        (
+            # With deprecated GTIN length
             "https://example.com/01/614141123452",
             "(01)00614141123452",
         ),
         (
-            "https://example.com/gtin/614141123452",
-            "(01)00614141123452",
-        ),
-        (
-            "https://example.com/gtin/614141123452/cpv/2A/lot/ABC123",
+            # With deprecated GTIN length and qualifiers
+            "https://example.com/01/00614141123452/22/2A/10/ABC123",
             "(01)00614141123452(22)2A(10)ABC123",
         ),
         (
-            "https://example.com/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123&foo=bar",
+            # Extra query parameters are ignored
+            "https://example.com/00/106141412345678908?02=00614141123452&37=25&10=ABC123&foo=bar",
             "(00)106141412345678908(02)00614141123452(37)25(10)ABC123",
         ),
     ],
@@ -498,8 +450,8 @@ def test_as_gs1_message(value: str, expected: str) -> None:
 @pytest.mark.parametrize(
     ("value", "ai", "expected"),
     [
-        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "01", ["00614141123452"]),
-        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "10", ["ABC123"]),
+        ("https://id.gs1.org/01/614141123452/10/ABC123", "01", ["00614141123452"]),
+        ("https://id.gs1.org/01/614141123452/10/ABC123", "10", ["ABC123"]),
     ],
 )
 def test_filter_element_strings_by_ai(value: str, ai: str, expected: list[str]) -> None:
@@ -511,8 +463,8 @@ def test_filter_element_strings_by_ai(value: str, ai: str, expected: list[str]) 
 @pytest.mark.parametrize(
     ("value", "data_title", "expected"),
     [
-        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "GTIN", ["00614141123452"]),
-        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "BATCH", ["ABC123"]),
+        ("https://id.gs1.org/01/614141123452/10/ABC123", "GTIN", ["00614141123452"]),
+        ("https://id.gs1.org/01/614141123452/10/ABC123", "BATCH", ["ABC123"]),
     ],
 )
 def test_filter_element_strings_by_data_title(
@@ -528,9 +480,9 @@ def test_filter_element_strings_by_data_title(
 @pytest.mark.parametrize(
     ("value", "ai", "expected"),
     [
-        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "01", "00614141123452"),
-        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "10", "ABC123"),
-        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "15", None),
+        ("https://id.gs1.org/01/614141123452/10/ABC123", "01", "00614141123452"),
+        ("https://id.gs1.org/01/614141123452/10/ABC123", "10", "ABC123"),
+        ("https://id.gs1.org/01/614141123452/10/ABC123", "15", None),
     ],
 )
 def test_get_element_strings_by_ai(value: str, ai: str, expected: str | None) -> None:
@@ -546,10 +498,10 @@ def test_get_element_strings_by_ai(value: str, ai: str, expected: str | None) ->
 @pytest.mark.parametrize(
     ("value", "data_title", "expected"),
     [
-        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "GTIN", "00614141123452"),
-        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "BATCH", "ABC123"),
-        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "LOT", "ABC123"),
-        ("https://id.gs1.org/gtin/614141123452/lot/ABC123", "BEST BY", None),
+        ("https://id.gs1.org/01/614141123452/10/ABC123", "GTIN", "00614141123452"),
+        ("https://id.gs1.org/01/614141123452/10/ABC123", "BATCH", "ABC123"),
+        ("https://id.gs1.org/01/614141123452/10/ABC123", "LOT", "ABC123"),
+        ("https://id.gs1.org/01/614141123452/10/ABC123", "BEST BY", None),
     ],
 )
 def test_get_element_strings_by_data_title(

--- a/tests/test_gs1_digital_link_uris.py
+++ b/tests/test_gs1_digital_link_uris.py
@@ -241,17 +241,17 @@ def test_parse_with_invalid_element_values(
         (
             # "15" is not a valid qualifier for GTIN
             "https://id.gs1.org/01/614141123452/15/20250324",
-            r"^Expected one of \(22, 10, 21\) as qualifier, got '15'.$",
+            r"^Expected one of \(22, 10, 21, 235\) as qualifier, got '15'.$",
         ),
         (
             # "22" is a valid qualifier, but not after "10"
             "https://id.gs1.org/01/614141123452/10/ABC123/22/123456789",
-            r"^Expected one of \(21\) as qualifier, got '22'.$",
+            r"^Expected one of \(21, 235\) as qualifier, got '22'.$",
         ),
         (
             # "10" is a valid qualifier, but not after "21"
             "https://id.gs1.org/01/01234567890128/21/12345XYZ/10/ABC123",
-            r"^Did not expect a qualifier, got '10'.$",
+            r"^Expected one of \(235\) as qualifier, got '10'.$",
         ),
         (
             # "10" is not a valid qualifier for SSCC

--- a/tests/test_gs1_digital_link_uris.py
+++ b/tests/test_gs1_digital_link_uris.py
@@ -409,9 +409,9 @@ def test_as_uri_errors() -> None:
             "https://id.gs1.org/01/00614141123452/22/2A/10/ABC123",
         ),
         (
-            # Extra query parameters are ignored
+            # Extra query parameters are ignored and query parameters are sorted
             "https://example.com/00/106141412345678908?02=00614141123452&37=25&10=ABC123&foo=bar",
-            "https://id.gs1.org/00/106141412345678908?02=00614141123452&37=25&10=ABC123",
+            "https://id.gs1.org/00/106141412345678908?02=00614141123452&10=ABC123&37=25",
         ),
     ],
 )

--- a/tests/test_gs1_digital_link_uris.py
+++ b/tests/test_gs1_digital_link_uris.py
@@ -4,9 +4,9 @@ import pytest
 
 from biip import ParseConfig, ParseError
 from biip.gs1_application_identifiers import GS1ApplicationIdentifier
+from biip.gs1_digital_link_uris import GS1DigitalLinkURI
 from biip.gs1_element_strings import GS1ElementString, GS1ElementStrings
 from biip.gs1_prefixes import GS1CompanyPrefix, GS1Prefix
-from biip.gs1_web_uris import GS1WebURI
 from biip.gtin import Gtin, GtinFormat
 from biip.sscc import Sscc
 
@@ -17,7 +17,7 @@ from biip.sscc import Sscc
         (
             # GTIN-12 by AI number
             "https://id.gs1.org/01/614141123452",
-            GS1WebURI(
+            GS1DigitalLinkURI(
                 value="https://id.gs1.org/01/614141123452",
                 element_strings=GS1ElementStrings(
                     [
@@ -41,7 +41,7 @@ from biip.sscc import Sscc
         (
             # GTIN-12 with custom domain, path prefix, and AI alias
             "https://example.com/foo/gtin/614141123452",
-            GS1WebURI(
+            GS1DigitalLinkURI(
                 value="https://example.com/foo/gtin/614141123452",
                 element_strings=GS1ElementStrings(
                     [
@@ -65,7 +65,7 @@ from biip.sscc import Sscc
         (
             # GTIN-12 and batch/lot number by AI number
             "https://id.gs1.org/01/614141123452/10/ABC123",
-            GS1WebURI(
+            GS1DigitalLinkURI(
                 value="https://id.gs1.org/01/614141123452/10/ABC123",
                 element_strings=GS1ElementStrings(
                     [
@@ -94,7 +94,7 @@ from biip.sscc import Sscc
         (
             # GTIN-12, CPV, and batch/lot number by AI alias
             "https://id.gs1.org/gtin/614141123452/cpv/2A/lot/ABC123",
-            GS1WebURI(
+            GS1DigitalLinkURI(
                 value="https://id.gs1.org/gtin/614141123452/cpv/2A/lot/ABC123",
                 element_strings=GS1ElementStrings(
                     [
@@ -128,7 +128,7 @@ from biip.sscc import Sscc
         (
             # GTIN-12 with extra query parameter that is ignored
             "https://id.gs1.org/01/614141123452?foo=bar",
-            GS1WebURI(
+            GS1DigitalLinkURI(
                 value="https://id.gs1.org/01/614141123452?foo=bar",
                 element_strings=GS1ElementStrings(
                     [
@@ -152,7 +152,7 @@ from biip.sscc import Sscc
         (
             # SSCC with content, count, and batch/lot number
             "https://id.gs1.org/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123",
-            GS1WebURI(
+            GS1DigitalLinkURI(
                 value="https://id.gs1.org/sscc/106141412345678908?02=00614141123452&37=25&10=ABC123",
                 element_strings=GS1ElementStrings(
                     [
@@ -201,8 +201,8 @@ from biip.sscc import Sscc
         ),
     ],
 )
-def test_parse(value: str, expected: GS1WebURI) -> None:
-    assert GS1WebURI.parse(value) == expected
+def test_parse(value: str, expected: GS1DigitalLinkURI) -> None:
+    assert GS1DigitalLinkURI.parse(value) == expected
 
 
 @pytest.mark.parametrize(
@@ -212,7 +212,7 @@ def test_parse(value: str, expected: GS1WebURI) -> None:
             # Invalid date "000000"
             "https://id.gs1.org/gtin/614141123452?15=000000",
             ParseConfig(gs1_element_strings_verify_date=False),
-            GS1WebURI(
+            GS1DigitalLinkURI(
                 value="https://id.gs1.org/gtin/614141123452?15=000000",
                 element_strings=GS1ElementStrings(
                     [
@@ -244,9 +244,9 @@ def test_parse(value: str, expected: GS1WebURI) -> None:
 def test_parse_with_invalid_element_values(
     value: str,
     config: ParseConfig,
-    expected: GS1WebURI,
+    expected: GS1DigitalLinkURI,
 ) -> None:
-    assert GS1WebURI.parse(value, config=config) == expected
+    assert GS1DigitalLinkURI.parse(value, config=config) == expected
 
 
 @pytest.mark.parametrize(
@@ -296,7 +296,7 @@ def test_parse_with_invalid_element_values(
 )
 def test_parse_error(value: str, error: str) -> None:
     with pytest.raises(ParseError, match=error):
-        GS1WebURI.parse(value)
+        GS1DigitalLinkURI.parse(value)
 
 
 @pytest.mark.parametrize(
@@ -331,7 +331,7 @@ def test_parse_error(value: str, error: str) -> None:
                     ),
                 ]
             ),
-            GS1WebURI(
+            GS1DigitalLinkURI(
                 value="https://id.gs1.org/01/07032069804988/10/0329?15=210526",
                 element_strings=GS1ElementStrings(
                     [
@@ -365,8 +365,10 @@ def test_parse_error(value: str, error: str) -> None:
         ),
     ],
 )
-def test_from_element_strings(value: GS1ElementStrings, expected: GS1WebURI) -> None:
-    assert GS1WebURI.from_element_strings(value) == expected
+def test_from_element_strings(
+    value: GS1ElementStrings, expected: GS1DigitalLinkURI
+) -> None:
+    assert GS1DigitalLinkURI.from_element_strings(value) == expected
 
 
 @pytest.mark.parametrize(
@@ -423,7 +425,7 @@ def test_as_uri(
     expected: str,
 ) -> None:
     assert (
-        GS1WebURI.parse(value).as_uri(
+        GS1DigitalLinkURI.parse(value).as_uri(
             domain=domain,
             prefix=prefix,
             short_names=short_names,
@@ -434,11 +436,11 @@ def test_as_uri(
 
 def test_as_uri_errors() -> None:
     with pytest.raises(ValueError, match="Prefix must not start with '/'"):
-        GS1WebURI.parse("https://example.com/gtin/614141123452").as_uri(
+        GS1DigitalLinkURI.parse("https://example.com/gtin/614141123452").as_uri(
             prefix="/prefix"
         )
     with pytest.raises(ValueError, match="Prefix must not end with '/'"):
-        GS1WebURI.parse("https://example.com/gtin/614141123452").as_uri(
+        GS1DigitalLinkURI.parse("https://example.com/gtin/614141123452").as_uri(
             prefix="prefix/"
         )
 
@@ -465,7 +467,7 @@ def test_as_uri_errors() -> None:
     ],
 )
 def test_as_canonical_uri(value: str, expected: str) -> None:
-    assert GS1WebURI.parse(value).as_canonical_uri() == expected
+    assert GS1DigitalLinkURI.parse(value).as_canonical_uri() == expected
 
 
 @pytest.mark.parametrize(
@@ -490,7 +492,7 @@ def test_as_canonical_uri(value: str, expected: str) -> None:
     ],
 )
 def test_as_gs1_message(value: str, expected: str) -> None:
-    assert GS1WebURI.parse(value).as_gs1_message().as_hri() == expected
+    assert GS1DigitalLinkURI.parse(value).as_gs1_message().as_hri() == expected
 
 
 @pytest.mark.parametrize(
@@ -501,7 +503,7 @@ def test_as_gs1_message(value: str, expected: str) -> None:
     ],
 )
 def test_filter_element_strings_by_ai(value: str, ai: str, expected: list[str]) -> None:
-    matches = GS1WebURI.parse(value).element_strings.filter(ai=ai)
+    matches = GS1DigitalLinkURI.parse(value).element_strings.filter(ai=ai)
 
     assert [element_string.value for element_string in matches] == expected
 
@@ -516,7 +518,9 @@ def test_filter_element_strings_by_ai(value: str, ai: str, expected: list[str]) 
 def test_filter_element_strings_by_data_title(
     value: str, data_title: str, expected: list[str]
 ) -> None:
-    matches = GS1WebURI.parse(value).element_strings.filter(data_title=data_title)
+    matches = GS1DigitalLinkURI.parse(value).element_strings.filter(
+        data_title=data_title
+    )
 
     assert [element_string.value for element_string in matches] == expected
 
@@ -530,7 +534,7 @@ def test_filter_element_strings_by_data_title(
     ],
 )
 def test_get_element_strings_by_ai(value: str, ai: str, expected: str | None) -> None:
-    element_string = GS1WebURI.parse(value).element_strings.get(ai=ai)
+    element_string = GS1DigitalLinkURI.parse(value).element_strings.get(ai=ai)
 
     if expected is None:
         assert element_string is None
@@ -551,7 +555,9 @@ def test_get_element_strings_by_ai(value: str, ai: str, expected: str | None) ->
 def test_get_element_strings_by_data_title(
     value: str, data_title: str, expected: str | None
 ) -> None:
-    element_string = GS1WebURI.parse(value).element_strings.get(data_title=data_title)
+    element_string = GS1DigitalLinkURI.parse(value).element_strings.get(
+        data_title=data_title
+    )
 
     if expected is None:
         assert element_string is None

--- a/tests/test_gs1_messages.py
+++ b/tests/test_gs1_messages.py
@@ -440,8 +440,8 @@ def test_as_hri(value: str, expected: str) -> None:
         )
     ],
 )
-def test_as_gs1_web_uri(value: str, expected: str) -> None:
-    assert GS1Message.parse(value).as_gs1_web_uri().value == expected
+def test_as_gs1_digital_link_uri(value: str, expected: str) -> None:
+    assert GS1Message.parse(value).as_gs1_digital_link_uri().value == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -5,10 +5,10 @@ import pytest
 
 from biip import ParseConfig, ParseResult, parse
 from biip.gs1_application_identifiers import GS1ApplicationIdentifier
+from biip.gs1_digital_link_uris import GS1DigitalLinkURI
 from biip.gs1_element_strings import GS1ElementString, GS1ElementStrings
 from biip.gs1_messages import GS1Message
 from biip.gs1_prefixes import GS1CompanyPrefix, GS1Prefix
-from biip.gs1_web_uris import GS1WebURI
 from biip.gtin import Gtin, GtinFormat
 from biip.rcn import Rcn, RcnRegion, RcnUsage
 from biip.sscc import Sscc
@@ -654,7 +654,7 @@ from biip.upc import Upc, UpcFormat
             ),
         ),
         (
-            # GS1 Web URI with GTIN-12, lot number, and expiration date
+            # GS1 Digital Link URI with GTIN-12, lot number, and expiration date
             "https://example.com/gtin/614141123452/lot/ABC123?15=250330",
             ParseResult(
                 value="https://example.com/gtin/614141123452/lot/ABC123?15=250330",
@@ -673,7 +673,7 @@ from biip.upc import Upc, UpcFormat
                     payload="61414112345",
                     check_digit=2,
                 ),
-                gs1_web_uri=GS1WebURI(
+                gs1_digital_link_uri=GS1DigitalLinkURI(
                     value="https://example.com/gtin/614141123452/lot/ABC123?15=250330",
                     element_strings=GS1ElementStrings(
                         [
@@ -718,8 +718,8 @@ from biip.upc import Upc, UpcFormat
             ),
         ),
         (
-            # GS1 Web URI with GTIN-12, lot number, and expiration date with GS1
-            # QR Code symbology identifier
+            # GS1 Digital Link URI with GTIN-12, lot number, and expiration date
+            # with GS1 QR Code symbology identifier
             "]Q3https://example.com/gtin/614141123452/lot/ABC123?15=250330",
             ParseResult(
                 value="]Q3https://example.com/gtin/614141123452/lot/ABC123?15=250330",
@@ -748,7 +748,7 @@ from biip.upc import Upc, UpcFormat
                     "Failed to get GS1 Application Identifier from "
                     "'https://example.com/gtin/614141123452/lot/ABC123?15=250330'."
                 ),
-                gs1_web_uri=GS1WebURI(
+                gs1_digital_link_uri=GS1DigitalLinkURI(
                     value="https://example.com/gtin/614141123452/lot/ABC123?15=250330",
                     element_strings=GS1ElementStrings(
                         [
@@ -899,8 +899,8 @@ def test_parse_invalid_data() -> None:
         result.gs1_message_error
         == "Failed to get GS1 Application Identifier from 'abc'."
     )
-    assert result.gs1_web_uri is None
-    assert result.gs1_web_uri_error is None
+    assert result.gs1_digital_link_uri is None
+    assert result.gs1_digital_link_uri_error is None
     assert result.sscc is None
     assert (
         result.sscc_error == "Failed to parse 'abc' as SSCC: Expected 18 digits, got 3."
@@ -919,9 +919,9 @@ def test_parse_invalid_http_uri() -> None:
     assert result.gtin_error is None
     assert result.gs1_message is None
     assert result.gs1_message_error is None
-    assert result.gs1_web_uri is None
+    assert result.gs1_digital_link_uri is None
     assert (
-        result.gs1_web_uri_error
+        result.gs1_digital_link_uri_error
         == "Expected a primary identifier in the path, got '/foo/bar'."
     )
     assert result.sscc is None

--- a/tests/test_parse.py
+++ b/tests/test_parse.py
@@ -654,10 +654,10 @@ from biip.upc import Upc, UpcFormat
             ),
         ),
         (
-            # GS1 Digital Link URI with GTIN-12, lot number, and expiration date
-            "https://example.com/gtin/614141123452/lot/ABC123?15=250330",
+            # GS1 Digital Link URI with GTIN-14, lot number, and expiration date
+            "https://example.com/01/00614141123452/10/ABC123?15=250330",
             ParseResult(
-                value="https://example.com/gtin/614141123452/lot/ABC123?15=250330",
+                value="https://example.com/01/00614141123452/10/ABC123?15=250330",
                 gtin=Gtin(
                     value="00614141123452",
                     format=GtinFormat.GTIN_12,
@@ -674,7 +674,7 @@ from biip.upc import Upc, UpcFormat
                     check_digit=2,
                 ),
                 gs1_digital_link_uri=GS1DigitalLinkURI(
-                    value="https://example.com/gtin/614141123452/lot/ABC123?15=250330",
+                    value="https://example.com/01/00614141123452/10/ABC123?15=250330",
                     element_strings=GS1ElementStrings(
                         [
                             GS1ElementString(
@@ -720,9 +720,9 @@ from biip.upc import Upc, UpcFormat
         (
             # GS1 Digital Link URI with GTIN-12, lot number, and expiration date
             # with GS1 QR Code symbology identifier
-            "]Q3https://example.com/gtin/614141123452/lot/ABC123?15=250330",
+            "]Q3https://example.com/01/614141123452/10/ABC123?15=250330",
             ParseResult(
-                value="]Q3https://example.com/gtin/614141123452/lot/ABC123?15=250330",
+                value="]Q3https://example.com/01/614141123452/10/ABC123?15=250330",
                 symbology_identifier=SymbologyIdentifier(
                     value="]Q3",
                     iso_symbology=ISOSymbology.QR_CODE,
@@ -746,10 +746,10 @@ from biip.upc import Upc, UpcFormat
                 ),
                 gs1_message_error=(
                     "Failed to get GS1 Application Identifier from "
-                    "'https://example.com/gtin/614141123452/lot/ABC123?15=250330'."
+                    "'https://example.com/01/614141123452/10/ABC123?15=250330'."
                 ),
                 gs1_digital_link_uri=GS1DigitalLinkURI(
-                    value="https://example.com/gtin/614141123452/lot/ABC123?15=250330",
+                    value="https://example.com/01/614141123452/10/ABC123?15=250330",
                     element_strings=GS1ElementStrings(
                         [
                             GS1ElementString(

--- a/tests/test_symbology.py
+++ b/tests/test_symbology.py
@@ -13,9 +13,9 @@ def test_gs1_symbology_with_gs1_messages() -> None:
     assert GS1Symbology.GS1_128 in GS1Symbology.with_gs1_messages()
 
 
-def test_gs1_symbology_with_gs1_web_uri() -> None:
-    assert GS1Symbology.GS1_DATAMATRIX in GS1Symbology.with_gs1_web_uri()
-    assert GS1Symbology.GS1_QR_CODE in GS1Symbology.with_gs1_web_uri()
+def test_gs1_symbology_with_gs1_digital_link_uri() -> None:
+    assert GS1Symbology.GS1_DATAMATRIX in GS1Symbology.with_gs1_digital_link_uri()
+    assert GS1Symbology.GS1_QR_CODE in GS1Symbology.with_gs1_digital_link_uri()
 
 
 def test_gs1_symbology_with_gtin() -> None:


### PR DESCRIPTION
This updates Biip's support for GS1 Digital Link URIs from v1.0 to v1.6 of the standard.

This includes:

- Renaming the class and APIs from `GS1WebURI` to `GS1DigitalLinkURI`, as the name changed in v1.1 of the standard.
- Remove support for application identifier aliases like "gtin" and "lot", as this was removed in v1.3 of the standard.
- Update the supported primary identifiers and their qualifiers.

Fixes #394 